### PR TITLE
Update properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 /target
+config_local.json5

--- a/config.json5
+++ b/config.json5
@@ -6,7 +6,7 @@
     "directory": ""
   },
   "hue": {
-    url: "https://192.168.1.150",
+    url: "https://localhost",
     retry_ms: 500,
     retry_max_delay_ms: 30000,
     stale_connection_timeout_ms: 60000,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 max_width = 180
+struct_lit_width = 35

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-max_width = 150
+max_width = 180

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -13,6 +13,7 @@ impl AppConfig {
     pub fn load() -> Self {
         Config::builder()
             .add_source(config::File::with_name("config").required(true))
+            .add_source(config::File::with_name("config_local").required(false))
             .add_source(config::Environment::default())
             .build()
             .unwrap()

--- a/src/domain/events.rs
+++ b/src/domain/events.rs
@@ -1,7 +1,9 @@
 use crate::domain::device::Device;
+use crate::domain::property::Number;
 
 #[derive(Debug)]
 pub enum Event {
     DiscoveredDevices(Vec<Device>),
     BooleanPropertyChanged { device_id: String, property_id: String, value: bool },
+    NumberPropertyChanged { device_id: String, property_id: String, value: Number },
 }

--- a/src/domain/events.rs
+++ b/src/domain/events.rs
@@ -3,4 +3,5 @@ use crate::domain::device::Device;
 #[derive(Debug)]
 pub enum Event {
     DiscoveredDevices(Vec<Device>),
+    BooleanPropertyChanged { device_id: String, property_id: String, value: bool },
 }

--- a/src/domain/events.rs
+++ b/src/domain/events.rs
@@ -1,9 +1,23 @@
 use crate::domain::device::Device;
-use crate::domain::property::Number;
+use crate::domain::property::{CartesianCoordinate, Gamut, Number};
 
 #[derive(Debug)]
 pub enum Event {
     DiscoveredDevices(Vec<Device>),
-    BooleanPropertyChanged { device_id: String, property_id: String, value: bool },
-    NumberPropertyChanged { device_id: String, property_id: String, value: Number },
+    BooleanPropertyChanged {
+        device_id: String,
+        property_id: String,
+        value: bool,
+    },
+    NumberPropertyChanged {
+        device_id: String,
+        property_id: String,
+        value: Number,
+    },
+    ColorPropertyChanged {
+        device_id: String,
+        property_id: String,
+        xy: CartesianCoordinate,
+        gamut: Option<Gamut>,
+    },
 }

--- a/src/domain/property/boolean_property.rs
+++ b/src/domain/property/boolean_property.rs
@@ -21,6 +21,10 @@ impl BooleanProperty {
         }
     }
 
+    pub fn value(&self) -> bool {
+        self.value
+    }
+
     pub fn set_value(&mut self, value: bool) -> Result<bool, PropertyError> {
         if !self.readonly {
             self.value = value;

--- a/src/domain/property/boolean_property.rs
+++ b/src/domain/property/boolean_property.rs
@@ -53,6 +53,10 @@ impl Property for BooleanProperty {
         self.external_id.as_deref()
     }
 
+    fn value_string(&self) -> String {
+        self.value.to_string()
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/domain/property/boolean_property.rs
+++ b/src/domain/property/boolean_property.rs
@@ -25,11 +25,11 @@ impl BooleanProperty {
         self.value
     }
 
-    pub fn set_value(&mut self, value: bool) -> Result<bool, PropertyError> {
+    pub fn set_value(&mut self, value: bool) -> Result<(), PropertyError> {
         if !self.readonly {
             self.value = value;
 
-            Ok(value)
+            Ok(())
         } else {
             Err(PropertyError::ReadOnly)
         }
@@ -87,7 +87,7 @@ mod tests {
         let result = property.set_value(true);
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true);
+        assert_eq!(result.unwrap(), ());
         assert_eq!(property.value, true);
     }
 

--- a/src/domain/property/color_property.rs
+++ b/src/domain/property/color_property.rs
@@ -23,7 +23,7 @@ impl ColorProperty {
         }
     }
 
-    pub fn set_value(&mut self, value: CartesianCoordinate, gamut: Option<Gamut>) -> Result<(CartesianCoordinate, Option<Gamut>), PropertyError> {
+    pub fn set_value(&mut self, value: CartesianCoordinate, gamut: Option<Gamut>) -> Result<(), PropertyError> {
         if self.readonly {
             return Err(PropertyError::ReadOnly);
         }
@@ -33,7 +33,7 @@ impl ColorProperty {
             self.gamut = gamut;
         }
 
-        Ok((self.xy.clone(), self.gamut.clone()))
+        Ok(())
     }
 }
 
@@ -71,7 +71,7 @@ impl Property for ColorProperty {
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(PartialEq, Debug)]
 pub struct CartesianCoordinate {
     x: f64,
     y: f64,
@@ -83,7 +83,7 @@ impl CartesianCoordinate {
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(PartialEq, Debug)]
 pub struct Gamut {
     red: CartesianCoordinate,
     green: CartesianCoordinate,

--- a/src/domain/property/color_property.rs
+++ b/src/domain/property/color_property.rs
@@ -48,6 +48,10 @@ impl Property for ColorProperty {
         self.external_id.as_deref()
     }
 
+    fn value_string(&self) -> String {
+        format!("CIE XY {{ x: {}, y: {} }}", self.xy.x, self.xy.y)
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/domain/property/color_property.rs
+++ b/src/domain/property/color_property.rs
@@ -12,14 +12,7 @@ pub struct ColorProperty {
 }
 
 impl ColorProperty {
-    pub fn new(
-        name: String,
-        property_type: PropertyType,
-        readonly: bool,
-        external_id: Option<String>,
-        xy: CartesianCoordinate,
-        gamut: Option<Gamut>,
-    ) -> Self {
+    pub fn new(name: String, property_type: PropertyType, readonly: bool, external_id: Option<String>, xy: CartesianCoordinate, gamut: Option<Gamut>) -> Self {
         ColorProperty {
             name,
             property_type,

--- a/src/domain/property/color_property.rs
+++ b/src/domain/property/color_property.rs
@@ -1,4 +1,4 @@
-use crate::domain::property::{Property, PropertyType};
+use crate::domain::property::{Property, PropertyError, PropertyType};
 use std::any::Any;
 
 #[derive(PartialEq, Debug)]
@@ -21,6 +21,19 @@ impl ColorProperty {
             xy,
             gamut,
         }
+    }
+
+    pub fn set_value(&mut self, value: CartesianCoordinate, gamut: Option<Gamut>) -> Result<(CartesianCoordinate, Option<Gamut>), PropertyError> {
+        if self.readonly {
+            return Err(PropertyError::ReadOnly);
+        }
+
+        self.xy = value;
+        if gamut.is_some() {
+            self.gamut = gamut;
+        }
+
+        Ok((self.xy.clone(), self.gamut.clone()))
     }
 }
 
@@ -58,7 +71,7 @@ impl Property for ColorProperty {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct CartesianCoordinate {
     x: f64,
     y: f64,
@@ -70,7 +83,7 @@ impl CartesianCoordinate {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Gamut {
     red: CartesianCoordinate,
     green: CartesianCoordinate,

--- a/src/domain/property/mod.rs
+++ b/src/domain/property/mod.rs
@@ -5,5 +5,5 @@ mod property;
 
 pub use boolean_property::BooleanProperty;
 pub use color_property::{CartesianCoordinate, ColorProperty, Gamut};
-pub use number_property::{NumberProperty, Unit};
+pub use number_property::{Number, NumberProperty, Unit};
 pub use property::{Property, PropertyError, PropertyType};

--- a/src/domain/property/number_property.rs
+++ b/src/domain/property/number_property.rs
@@ -48,7 +48,7 @@ impl NumberProperty {
         }
     }
 
-    pub fn set_positive_int(&mut self, value: u64) -> Result<u64, PropertyError> {
+    pub fn set_positive_int(&mut self, value: u64) -> Result<(), PropertyError> {
         if self.readonly {
             return Err(PropertyError::ReadOnly);
         }
@@ -72,10 +72,10 @@ impl NumberProperty {
         }
 
         self.value = Number::PositiveInt(value);
-        Ok(value)
+        Ok(())
     }
 
-    pub fn set_negative_int(&mut self, value: i64) -> Result<i64, PropertyError> {
+    pub fn set_negative_int(&mut self, value: i64) -> Result<(), PropertyError> {
         if self.readonly {
             return Err(PropertyError::ReadOnly);
         }
@@ -99,10 +99,10 @@ impl NumberProperty {
         }
 
         self.value = Number::NegativeInt(value);
-        Ok(value)
+        Ok(())
     }
 
-    pub fn set_float(&mut self, value: f64) -> Result<f64, PropertyError> {
+    pub fn set_float(&mut self, value: f64) -> Result<(), PropertyError> {
         if self.readonly {
             return Err(PropertyError::ReadOnly);
         }
@@ -126,18 +126,18 @@ impl NumberProperty {
         }
 
         self.value = Number::Float(value);
-        Ok(value)
+        Ok(())
     }
 
     pub fn value(&self) -> &Number {
         &self.value
     }
 
-    pub fn set_value(&mut self, value: Number) -> Result<Number, PropertyError> {
+    pub fn set_value(&mut self, value: Number) -> Result<(), PropertyError> {
         match value {
-            Number::PositiveInt(n) => self.set_positive_int(n).map(|_| value),
-            Number::NegativeInt(n) => self.set_negative_int(n).map(|_| value),
-            Number::Float(n) => self.set_float(n).map(|_| value),
+            Number::PositiveInt(n) => self.set_positive_int(n),
+            Number::NegativeInt(n) => self.set_negative_int(n),
+            Number::Float(n) => self.set_float(n),
         }
     }
 }
@@ -344,7 +344,7 @@ mod tests {
             let result = property.set_positive_int(7);
 
             assert!(result.is_ok());
-            assert_eq!(result.unwrap(), 7);
+            assert_eq!(result.unwrap(), ());
             assert_eq!(property.value, Number::PositiveInt(7));
         }
 
@@ -403,7 +403,7 @@ mod tests {
             let result = property.set_negative_int(-7);
 
             assert!(result.is_ok());
-            assert_eq!(result.unwrap(), -7);
+            assert_eq!(result.unwrap(), ());
             assert_eq!(property.value, Number::NegativeInt(-7));
         }
 
@@ -462,7 +462,7 @@ mod tests {
             let result = property.set_float(7.0);
 
             assert!(result.is_ok());
-            assert_eq!(result.unwrap(), 7.0);
+            assert_eq!(result.unwrap(), ());
             assert_eq!(property.value, Number::Float(7.0));
         }
 

--- a/src/domain/property/number_property.rs
+++ b/src/domain/property/number_property.rs
@@ -1,6 +1,6 @@
 use crate::domain::property::{Property, PropertyError, PropertyType};
 use std::any::Any;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 
 #[derive(PartialEq, Debug)]
 pub struct NumberProperty {
@@ -128,6 +128,18 @@ impl NumberProperty {
         self.value = Number::Float(value);
         Ok(value)
     }
+
+    pub fn value(&self) -> &Number {
+        &self.value
+    }
+
+    pub fn set_value(&mut self, value: Number) -> Result<Number, PropertyError> {
+        match value {
+            Number::PositiveInt(n) => self.set_positive_int(n).map(|_| value),
+            Number::NegativeInt(n) => self.set_negative_int(n).map(|_| value),
+            Number::Float(n) => self.set_float(n).map(|_| value),
+        }
+    }
 }
 
 impl Property for NumberProperty {
@@ -145,6 +157,10 @@ impl Property for NumberProperty {
 
     fn external_id(&self) -> Option<&str> {
         self.external_id.as_deref()
+    }
+
+    fn value_string(&self) -> String {
+        self.value.to_string()
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -257,6 +273,16 @@ pub enum Number {
     PositiveInt(u64),
     NegativeInt(i64),
     Float(f64),
+}
+
+impl Display for Number {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Number::PositiveInt(n) => write!(f, "{}", n),
+            Number::NegativeInt(n) => write!(f, "{}", n),
+            Number::Float(n) => write!(f, "{}", n),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/domain/property/property.rs
+++ b/src/domain/property/property.rs
@@ -9,6 +9,9 @@ pub trait Property: Debug + Send + Sync {
     fn readonly(&self) -> bool;
     fn external_id(&self) -> Option<&str>;
 
+    /// Returns a string representation of the value of the property
+    fn value_string(&self) -> String;
+
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
     fn eq_dyn(&self, other: &dyn Property) -> bool;
@@ -39,4 +42,6 @@ pub enum PropertyError {
     ValueTooLarge,
     #[error("value type is incorrect")]
     IncorrectValueType,
+    #[error("missing property")]
+    MissingProperty,
 }

--- a/src/domain/property/property.rs
+++ b/src/domain/property/property.rs
@@ -35,8 +35,8 @@ pub enum PropertyError {
     ReadOnly,
     #[error("value is smaller than the minimum value")]
     ValueTooSmall,
-    #[error("value is smaller than the minimum value")]
+    #[error("value is larger than the maximum value")]
     ValueTooLarge,
-    #[error("value is smaller than the minimum value")]
+    #[error("value type is incorrect")]
     IncorrectValueType,
 }

--- a/src/hue/domain/light_get.rs
+++ b/src/hue/domain/light_get.rs
@@ -64,3 +64,25 @@ pub enum GamutType {
     B,
     C,
 }
+
+#[derive(Debug, Deserialize)]
+pub struct LightChanged {
+    pub id: String,
+    pub owner: Owner,
+    pub on: Option<On>,
+    pub dimming: Option<Dimming>,
+    pub color_temperature: Option<ChangedColorTemperature>,
+    pub color: Option<ChangedColor>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ChangedColorTemperature {
+    pub mirek: u64, // >= 153 && <= 500, color temperature in mirek or null when the light color is not in the ct spectrum
+    pub mirek_valid: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ChangedColor {
+    pub xy: Xy,
+    pub gamut: Option<ColorGamut>,
+}

--- a/src/hue/domain/light_get.rs
+++ b/src/hue/domain/light_get.rs
@@ -1,3 +1,4 @@
+use crate::domain::property::{CartesianCoordinate, Gamut};
 use crate::hue::domain::hue_response::Owner;
 use serde::Deserialize;
 
@@ -56,6 +57,16 @@ pub struct ColorGamut {
     pub red: Xy,
     pub green: Xy,
     pub blue: Xy,
+}
+
+impl ColorGamut {
+    pub fn take_gamut(&mut self) -> Gamut {
+        Gamut::new(
+            CartesianCoordinate::new(self.red.x, self.red.y),
+            CartesianCoordinate::new(self.green.x, self.green.y),
+            CartesianCoordinate::new(self.blue.x, self.blue.y),
+        )
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/hue/domain/mod.rs
+++ b/src/hue/domain/mod.rs
@@ -1,7 +1,9 @@
 mod device_get;
 mod hue_response;
 mod light_get;
+mod sse_payload;
 
 pub(super) use device_get::*;
 pub(super) use hue_response::*;
 pub(super) use light_get::*;
+pub(super) use sse_payload::*;

--- a/src/hue/domain/sse_payload.rs
+++ b/src/hue/domain/sse_payload.rs
@@ -1,0 +1,125 @@
+use crate::hue::domain::LightChanged;
+use serde::{Deserialize, Deserializer};
+use serde_json::Value;
+use std::ops::IndexMut;
+
+#[derive(Debug, Deserialize)]
+pub struct ServerSentEventPayload {
+    pub id: String,
+    pub r#type: DataType,
+    #[serde(rename = "creationtime")]
+    pub creation_time: String,
+    pub data: Vec<ChangedProperty>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DataType {
+    Add,
+    Update,
+    Delete,
+    Error,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ChangedProperty {
+    Light(LightChanged),
+    #[serde(untagged)]
+    Unknown(UnknownProperty),
+}
+
+#[derive(Debug)]
+pub struct UnknownProperty {
+    pub property_type: String,
+}
+
+impl<'de> Deserialize<'de> for UnknownProperty {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut value = Value::deserialize(deserializer)?;
+        match value.index_mut("type").take() {
+            Value::String(property_type) => Ok(UnknownProperty { property_type }),
+            _ => Err(serde::de::Error::missing_field("type")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_a_known_property_type() -> Result<(), serde_json::Error> {
+        let json = r#"
+        [
+          {
+            "creationtime": "2025-03-07T19:13:41Z",
+            "data": [
+              {
+                "id": "31e6d98c-09ca-4538-b4ea-b57c8c540b3e",
+                "id_v1": "/lights/22",
+                "on": {
+                  "on": false
+                },
+                "owner": {
+                  "rid": "84a3be14-5d90-4165-ac64-818b7981bb32",
+                  "rtype": "device"
+                },
+                "service_id": 0,
+                "type": "light"
+              }
+            ],
+            "id": "11c2f169-9c29-444b-9ef6-4868f6d2daf6",
+            "type": "update"
+          }
+        ]
+        "#;
+
+        let result = serde_json::from_str::<Vec<ServerSentEventPayload>>(json)?;
+        assert_eq!(result.len(), 1);
+        let first_result = &result[0];
+        assert_eq!(first_result.data.len(), 1);
+        assert!(matches!(&first_result.data[0], ChangedProperty::Light(LightChanged { .. })));
+
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize_an_unknown_property_types_returns_unknown() -> Result<(), serde_json::Error> {
+        let json = r#"
+        [
+          {
+            "creationtime": "2025-03-07T19:13:41Z",
+            "data": [
+              {
+                "id": "31e6d98c-09ca-4538-b4ea-b57c8c540b3e",
+                "id_v1": "/lights/22",
+                "on": {
+                  "on": false
+                },
+                "owner": {
+                  "rid": "84a3be14-5d90-4165-ac64-818b7981bb32",
+                  "rtype": "device"
+                },
+                "service_id": 0,
+                "type": "unknown"
+              }
+            ],
+            "id": "11c2f169-9c29-444b-9ef6-4868f6d2daf6",
+            "type": "update"
+          }
+        ]
+        "#;
+
+        let result = serde_json::from_str::<Vec<ServerSentEventPayload>>(json)?;
+        assert_eq!(result.len(), 1);
+        let first_result = &result[0];
+        assert_eq!(first_result.data.len(), 1);
+        assert!(matches!(&first_result.data[0], ChangedProperty::Unknown(UnknownProperty { property_type }) if property_type == "unknown"));
+
+        Ok(())
+    }
+}

--- a/src/hue/map_light_changed.rs
+++ b/src/hue/map_light_changed.rs
@@ -21,6 +21,14 @@ pub fn map_light_changed_property(property: LightChanged) -> Vec<Event> {
         });
     }
 
+    if let Some(color_temperature) = property.color_temperature {
+        events.push(Event::NumberPropertyChanged {
+            device_id: property.owner.rid.to_string(),
+            property_id: "colorTemperature".to_string(),
+            value: Number::PositiveInt(color_temperature.mirek.mirek_to_kelvin()),
+        });
+    }
+
     if let Some(color) = property.color {
         events.push(Event::ColorPropertyChanged {
             device_id: property.owner.rid.to_string(),

--- a/src/hue/map_light_changed.rs
+++ b/src/hue/map_light_changed.rs
@@ -1,0 +1,15 @@
+use crate::domain::events::Event;
+use crate::hue::domain::LightChanged;
+
+pub fn map_light_changed_property(property: LightChanged) -> Vec<Event> {
+    let mut events = Vec::<Event>::with_capacity(1);
+    if let Some(on) = property.on {
+        events.push(Event::BooleanPropertyChanged {
+            device_id: property.owner.rid.to_string(),
+            property_id: "on".to_string(),
+            value: on.on,
+        });
+    }
+
+    events
+}

--- a/src/hue/map_light_changed.rs
+++ b/src/hue/map_light_changed.rs
@@ -1,13 +1,22 @@
 use crate::domain::events::Event;
+use crate::domain::property::Number;
 use crate::hue::domain::LightChanged;
 
 pub fn map_light_changed_property(property: LightChanged) -> Vec<Event> {
-    let mut events = Vec::<Event>::with_capacity(1);
+    let mut events = Vec::<Event>::with_capacity(2);
     if let Some(on) = property.on {
         events.push(Event::BooleanPropertyChanged {
             device_id: property.owner.rid.to_string(),
             property_id: "on".to_string(),
             value: on.on,
+        });
+    }
+
+    if let Some(dimming) = property.dimming {
+        events.push(Event::NumberPropertyChanged {
+            device_id: property.owner.rid.to_string(),
+            property_id: "brightness".to_string(),
+            value: Number::Float(dimming.brightness),
         });
     }
 

--- a/src/hue/map_light_changed.rs
+++ b/src/hue/map_light_changed.rs
@@ -1,9 +1,10 @@
 use crate::domain::events::Event;
-use crate::domain::property::Number;
+use crate::domain::property::{CartesianCoordinate, Number};
+use crate::extensions::unsigned_ints_ext::MirekConversions;
 use crate::hue::domain::LightChanged;
 
 pub fn map_light_changed_property(property: LightChanged) -> Vec<Event> {
-    let mut events = Vec::<Event>::with_capacity(2);
+    let mut events = Vec::<Event>::with_capacity(3);
     if let Some(on) = property.on {
         events.push(Event::BooleanPropertyChanged {
             device_id: property.owner.rid.to_string(),
@@ -17,6 +18,15 @@ pub fn map_light_changed_property(property: LightChanged) -> Vec<Event> {
             device_id: property.owner.rid.to_string(),
             property_id: "brightness".to_string(),
             value: Number::Float(dimming.brightness),
+        });
+    }
+
+    if let Some(color) = property.color {
+        events.push(Event::ColorPropertyChanged {
+            device_id: property.owner.rid.to_string(),
+            property_id: "color".to_string(),
+            xy: CartesianCoordinate::new(color.xy.x, color.xy.y),
+            gamut: color.gamut.map(|mut g| g.take_gamut()),
         });
     }
 

--- a/src/hue/map_lights.rs
+++ b/src/hue/map_lights.rs
@@ -54,13 +54,7 @@ pub fn map_lights(lights: Vec<LightGet>, device_map: &mut HashMap<String, Device
                     false,
                     Some(light.id.clone()),
                     CartesianCoordinate::new(color.xy.x, color.xy.y),
-                    color.gamut.map(|g| {
-                        Gamut::new(
-                            CartesianCoordinate::new(g.red.x, g.red.y),
-                            CartesianCoordinate::new(g.green.x, g.green.y),
-                            CartesianCoordinate::new(g.blue.x, g.blue.y),
-                        )
-                    }),
+                    color.gamut.map(|mut g| g.take_gamut()),
                 ));
                 properties.insert(brightness_property.name().to_owned(), brightness_property);
             });

--- a/src/hue/map_lights.rs
+++ b/src/hue/map_lights.rs
@@ -1,5 +1,5 @@
 use crate::domain::device::{Device, DeviceType};
-use crate::domain::property::{BooleanProperty, CartesianCoordinate, ColorProperty, Gamut, NumberProperty, Property, PropertyType, Unit};
+use crate::domain::property::{BooleanProperty, CartesianCoordinate, ColorProperty, NumberProperty, Property, PropertyType, Unit};
 use crate::extensions::unsigned_ints_ext::MirekConversions;
 use crate::hue::domain::{DeviceGet, LightGet};
 use std::collections::HashMap;
@@ -83,6 +83,7 @@ pub enum MapLightsError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::property::Gamut;
     use crate::hue::domain::{HueResponse, Metadata, ProductData};
     use pretty_assertions::assert_eq;
 

--- a/src/hue/map_lights.rs
+++ b/src/hue/map_lights.rs
@@ -15,13 +15,7 @@ pub fn map_lights(lights: Vec<LightGet>, device_map: &mut HashMap<String, Device
 
             let mut properties = HashMap::with_capacity(4);
 
-            let on_property: Box<dyn Property> = Box::new(BooleanProperty::new(
-                "on".to_string(),
-                PropertyType::On,
-                false,
-                Some(light.id.clone()),
-                light.on.on,
-            ));
+            let on_property: Box<dyn Property> = Box::new(BooleanProperty::new("on".to_string(), PropertyType::On, false, Some(light.id.clone()), light.on.on));
             properties.insert(on_property.name().to_owned(), on_property);
 
             light.dimming.map(|dimming| {

--- a/src/hue/mod.rs
+++ b/src/hue/mod.rs
@@ -1,6 +1,7 @@
 mod client;
 mod discoverer;
 mod domain;
+mod map_light_changed;
 mod map_lights;
 mod observer;
 

--- a/src/hue/mod.rs
+++ b/src/hue/mod.rs
@@ -2,6 +2,8 @@ mod client;
 mod discoverer;
 mod domain;
 mod map_lights;
+mod observer;
 
 pub use client::{HueClientError, new_client};
 pub use discoverer::{DiscoverError, discover};
+pub use observer::observe;

--- a/src/hue/mod.rs
+++ b/src/hue/mod.rs
@@ -1,4 +1,7 @@
-pub mod client;
+mod client;
+mod discoverer;
 mod domain;
 mod map_lights;
-pub mod observer;
+
+pub use client::{HueClientError, new_client};
+pub use discoverer::{DiscoverError, discover};

--- a/src/hue/observer.rs
+++ b/src/hue/observer.rs
@@ -27,9 +27,12 @@ pub async fn observe(client: &Client, config: &AppConfig) -> Result<(), Box<dyn 
         }
     });
 
-    sse::listen::<Vec<ServerSentEventPayload>>(tx, &client, &sse_config)
-        .await
-        .expect("Could not listen to SSE stream");
+    let cloned_client = client.clone();
+    task::spawn(async move {
+        sse::listen::<Vec<ServerSentEventPayload>>(tx, &cloned_client, &sse_config)
+            .await
+            .expect("Could not listen to SSE stream");
+    });
 
     Ok(())
 }

--- a/src/hue/observer.rs
+++ b/src/hue/observer.rs
@@ -1,13 +1,21 @@
 use crate::app_config::AppConfig;
 use crate::hue::domain::ServerSentEventPayload;
 use crate::sse;
+use crate::sse::Config;
 use reqwest::Client;
 use std::error::Error;
 use tracing::instrument;
 
 #[instrument(skip_all)]
 pub async fn observe(client: &Client, config: &AppConfig) -> Result<(), Box<dyn Error>> {
-    sse::listen::<Vec<ServerSentEventPayload>>(&client, &config)
+    let sse_config = Config {
+        url: config.hue().url().to_owned(),
+        retry_ms: config.hue().retry_ms(),
+        retry_max_delay: config.hue().retry_max_delay_ms(),
+        stale_connection_timeout_ms: config.hue().stale_connection_timeout_ms(),
+    };
+
+    sse::listen::<Vec<ServerSentEventPayload>>(&client, &sse_config)
         .await
         .expect("Could not listen to SSE stream");
 

--- a/src/hue/observer.rs
+++ b/src/hue/observer.rs
@@ -1,0 +1,15 @@
+use crate::app_config::AppConfig;
+use crate::hue::domain::ServerSentEventPayload;
+use crate::sse;
+use reqwest::Client;
+use std::error::Error;
+use tracing::instrument;
+
+#[instrument(skip_all)]
+pub async fn observe(client: &Client, config: &AppConfig) -> Result<(), Box<dyn Error>> {
+    sse::listen::<Vec<ServerSentEventPayload>>(&client, &config)
+        .await
+        .expect("Could not listen to SSE stream");
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(|_| Vec::new()); // Errors are already logged in the function
     info!("✅  Loaded flows");
 
-    let hue_client = hue::client::new_client(&config)?;
+    let hue_client = hue::new_client(&config)?;
 
     let (tx, rx) = mpsc::channel::<Event>(config.core().store_buffer_size());
     let mut store = Store::new(rx);
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
     info!("✅  Initialized store");
 
-    let hue_devices = hue::observer::observe(&hue_client, &config).await.expect("Could not observe Hue");
+    let hue_devices = hue::discover(&hue_client, &config).await.expect("Could not discover Hue devices");
     trace!("Observed Hue devices: {:?}", &hue_devices);
     tx.send(Event::DiscoveredDevices(hue_devices))
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ use crate::domain::events::Event;
 use crate::store::Store;
 use crate::store_listener::store_listener;
 use tokio::sync::mpsc;
-use tokio::task;
-use tracing::{info, trace};
+use tokio::{signal, task};
+use tracing::{error, info, trace};
 
 mod app_config;
 mod domain;
@@ -56,6 +56,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("🔥 {} is up and running", env!("CARGO_PKG_NAME"));
 
     hue::observe(&hue_client, &config).await?;
+
+    match signal::ctrl_c().await {
+        Ok(()) => {}
+        Err(err) => {
+            error!("Unable to listen for shutdown signal: {}", err);
+        }
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("✅  Discovered all devices");
     info!("🔥 {} is up and running", env!("CARGO_PKG_NAME"));
 
-    hue::observe(&hue_client, &config).await?;
+    hue::observe(tx.clone(), &hue_client, &config).await?;
 
     match signal::ctrl_c().await {
         Ok(()) => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod extensions;
 mod flow_engine;
 mod flow_loader;
 mod hue;
+mod property_changed_reducer;
 mod sse;
 mod store;
 mod store_listener;

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("✅  Discovered all devices");
     info!("🔥 {} is up and running", env!("CARGO_PKG_NAME"));
 
-    sse::listen(&hue_client, &config).await.expect("Could not listen to SSE stream");
+    hue::observe(&hue_client, &config).await?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use crate::app_config::AppConfig;
 use crate::domain::events::Event;
-use crate::sse_listen::listen;
 use crate::store::Store;
 use crate::store_listener::store_listener;
 use tokio::sync::mpsc;
@@ -13,7 +12,7 @@ mod extensions;
 mod flow_engine;
 mod flow_loader;
 mod hue;
-mod sse_listen;
+mod sse;
 mod store;
 mod store_listener;
 
@@ -56,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("✅  Discovered all devices");
     info!("🔥 {} is up and running", env!("CARGO_PKG_NAME"));
 
-    listen(&hue_client, &config).await.expect("Could not listen to SSE stream");
+    sse::listen(&hue_client, &config).await.expect("Could not listen to SSE stream");
 
     Ok(())
 }

--- a/src/property_changed_reducer.rs
+++ b/src/property_changed_reducer.rs
@@ -1,10 +1,16 @@
 use crate::domain::property::{Property, PropertyError};
 use crate::store::DeviceMap;
-use std::any::type_name;
+use std::any::{Any, type_name, type_name_of_val};
+use thiserror::Error;
 use tracing::{info, warn};
 
 #[inline(always)]
-pub(crate) async fn reduce_property_changed_event<F, T>(devices: &mut DeviceMap, device_id: &str, property_id: &str, set_value: F)
+pub(crate) async fn reduce_property_changed_event<F, T>(
+    devices: &mut DeviceMap,
+    device_id: &str,
+    property_id: &str,
+    set_value: F,
+) -> Result<(), ReducerError>
 where
     F: FnOnce(&mut T) -> Result<(), PropertyError>,
     T: Property + 'static,
@@ -14,26 +20,35 @@ where
     let Some(device) = write_guard.get_mut(device_id) else {
         #[rustfmt::skip]
         warn!(device_id, "⚠️ Received property changed event for unknown device '{}'", device_id);
-        return;
+        return Err(ReducerError::UnknownDevice {
+            device_id: device_id.to_string(),
+        });
     };
 
     let Some(property) = device.properties.get_mut(property_id) else {
         #[rustfmt::skip]
         warn!(device_id = device.id,"⚠️ Unknown property '{}' for device '{}'", property_id, device.name);
-        return;
+        return Err(ReducerError::UnknownProperty {
+            device_id: device_id.to_string(),
+            property_id: property_id.to_string(),
+        });
     };
 
     let previous_value = property.value_string();
     let Some(downcast_property) = property.as_any_mut().downcast_mut::<T>() else {
         #[rustfmt::skip]
-        warn!(device_id, "⚠️ Expected {} property for property '{}'", type_name::<T>(), &property_id);
-        return;
+        warn!(device_id, "⚠️ Expected '{}' property for property '{}'", type_name::<T>(), &property_id);
+        return Err(ReducerError::IncorrectPropertyType {
+            device_id: device_id.to_string(),
+            property_id: property_id.to_string(),
+            expected_type: type_name::<T>().to_owned(),
+        });
     };
 
     if let Err(err) = set_value(downcast_property) {
         #[rustfmt::skip]
         warn!(device_id = device.id, "⚠️ Could not set value for property '{}': {}", property_id, err);
-        return;
+        return Err(ReducerError::PropertyChangedError(err));
     }
 
     info!(
@@ -44,4 +59,112 @@ where
         property.value_string(),
         previous_value
     );
+    Ok(())
+}
+
+#[derive(Error, PartialEq, Debug)]
+pub enum ReducerError {
+    #[error("unknown device '{device_id}'")]
+    UnknownDevice { device_id: String },
+    #[error("unknown property '{property_id}' for device '{device_id}'")]
+    UnknownProperty { device_id: String, property_id: String },
+    #[error("expected device '{device_id}' to have property '{property_id}' of type '{expected_type}'")]
+    IncorrectPropertyType {
+        device_id: String,
+        property_id: String,
+        expected_type: String,
+    },
+    #[error(transparent)]
+    PropertyChangedError(PropertyError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::device::{Device, DeviceType};
+    use crate::domain::property::{BooleanProperty, NumberProperty, PropertyType};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use test_log::test;
+    use tokio::sync::RwLock;
+
+    const DEVICE_ID: &str = "079e0321-7e18-46bc-bc16-fcbc3dd09e30";
+
+    fn create_devices() -> DeviceMap {
+        let on_property: Box<dyn Property> = Box::new(BooleanProperty::new(
+            "on".to_string(),
+            PropertyType::On,
+            false,
+            Some("43e4f3a7-8b35-4b0c-a2ba-e6ca8f4c099b".to_string()),
+            false,
+        ));
+
+        let device = Device {
+            id: DEVICE_ID.to_string(),
+            r#type: DeviceType::Light,
+            manufacturer: "Signify Netherlands B.V.".to_string(),
+            model_id: "LWA004".to_string(),
+            product_name: "Hue filament bulb".to_string(),
+            name: "Woonkamer".to_string(),
+            properties: HashMap::from([(on_property.name().to_string(), on_property)]),
+            external_id: None,
+            address: None,
+        };
+
+        Arc::new(RwLock::new(HashMap::from([(DEVICE_ID.to_string(), device)])))
+    }
+
+    #[test(tokio::test)]
+    async fn reduce_returns_error_if_the_device_is_unknown() {
+        let mut devices = create_devices();
+        let result = reduce_property_changed_event(&mut devices, "unknown", "on", |_: &mut BooleanProperty| Ok(())).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            ReducerError::UnknownDevice {
+                device_id: "unknown".to_string()
+            }
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn reduce_returns_error_if_the_property_is_unknown() {
+        let mut devices = create_devices();
+        let result = reduce_property_changed_event(&mut devices, DEVICE_ID, "unknown", |_: &mut BooleanProperty| Ok(())).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            ReducerError::UnknownProperty {
+                device_id: DEVICE_ID.to_string(),
+                property_id: "unknown".to_string(),
+            }
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn reduce_returns_error_if_the_property_type_is_incorrect() {
+        let mut devices = create_devices();
+        let result = reduce_property_changed_event(&mut devices, DEVICE_ID, "on", |_: &mut NumberProperty| Ok(())).await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            ReducerError::IncorrectPropertyType {
+                device_id: DEVICE_ID.to_string(),
+                property_id: "on".to_string(),
+                expected_type: "hearth::domain::property::number_property::NumberProperty".to_string()
+            }
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn reduce_returns_error_if_the_lambda_returns_an_error() {
+        let mut devices = create_devices();
+        let result = reduce_property_changed_event(&mut devices, DEVICE_ID, "on", |_: &mut BooleanProperty| Err(PropertyError::ReadOnly)).await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), ReducerError::PropertyChangedError(PropertyError::ReadOnly));
+    }
 }

--- a/src/property_changed_reducer.rs
+++ b/src/property_changed_reducer.rs
@@ -1,0 +1,47 @@
+use crate::domain::property::{Property, PropertyError};
+use crate::store::DeviceMap;
+use std::any::type_name;
+use tracing::{info, warn};
+
+#[inline(always)]
+pub(crate) async fn reduce_property_changed_event<F, T>(devices: &mut DeviceMap, device_id: &str, property_id: &str, set_value: F)
+where
+    F: FnOnce(&mut T) -> Result<(), PropertyError>,
+    T: Property + 'static,
+{
+    let mut write_guard = devices.write().await;
+
+    let Some(device) = write_guard.get_mut(device_id) else {
+        #[rustfmt::skip]
+        warn!(device_id, "⚠️ Received property changed event for unknown device '{}'", device_id);
+        return;
+    };
+
+    let Some(property) = device.properties.get_mut(property_id) else {
+        #[rustfmt::skip]
+        warn!(device_id = device.id,"⚠️ Unknown property '{}' for device '{}'", property_id, device.name);
+        return;
+    };
+
+    let previous_value = property.value_string();
+    let Some(downcast_property) = property.as_any_mut().downcast_mut::<T>() else {
+        #[rustfmt::skip]
+        warn!(device_id, "⚠️ Expected {} property for property '{}'", type_name::<T>(), &property_id);
+        return;
+    };
+
+    if let Err(err) = set_value(downcast_property) {
+        #[rustfmt::skip]
+        warn!(device_id = device.id, "⚠️ Could not set value for property '{}': {}", property_id, err);
+        return;
+    }
+
+    info!(
+        device_id = device.id,
+        "🟢 Updated device '{}', set '{}' to '{}', was '{}'",
+        device.name,
+        property.name(),
+        property.value_string(),
+        previous_value
+    );
+}

--- a/src/sse/listen.rs
+++ b/src/sse/listen.rs
@@ -46,7 +46,6 @@ where
     Ok(())
 }
 
-#[instrument(skip(client, config))]
 async fn connect_sse_stream<T>(client: &Client, config: &Config) -> Result<(), Box<dyn Error>>
 where
     T: DeserializeOwned + Debug,

--- a/src/sse/listen.rs
+++ b/src/sse/listen.rs
@@ -3,8 +3,8 @@ use futures::StreamExt;
 use reqwest::{Client, StatusCode};
 use std::error::Error;
 use tokio::time::timeout;
-use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
+use tokio_retry::strategy::{ExponentialBackoff, jitter};
 use tracing::{error, info, instrument, warn};
 
 #[instrument(skip(client, config))]

--- a/src/sse/mod.rs
+++ b/src/sse/mod.rs
@@ -1,3 +1,4 @@
 mod listen;
+mod server_sent_event;
 
 pub use listen::listen;

--- a/src/sse/mod.rs
+++ b/src/sse/mod.rs
@@ -1,4 +1,4 @@
 mod listen;
 mod server_sent_event;
 
-pub use listen::listen;
+pub use listen::{Config, listen};

--- a/src/sse/mod.rs
+++ b/src/sse/mod.rs
@@ -2,3 +2,4 @@ mod listen;
 mod server_sent_event;
 
 pub use listen::{Config, listen};
+pub use server_sent_event::ServerSentEvent;

--- a/src/sse/mod.rs
+++ b/src/sse/mod.rs
@@ -1,0 +1,3 @@
+mod listen;
+
+pub use listen::listen;

--- a/src/sse/server_sent_event.rs
+++ b/src/sse/server_sent_event.rs
@@ -1,0 +1,103 @@
+use serde::de::DeserializeOwned;
+
+#[derive(Debug, PartialEq)]
+pub struct ServerSentEvent<T> {
+    pub id: Option<String>,
+    pub event: Option<String>,
+    pub retry: Option<usize>,
+    pub comment: Option<String>,
+    pub data: Option<T>,
+}
+
+impl<T> ServerSentEvent<T>
+where
+    T: DeserializeOwned,
+{
+    pub fn from_str(s: &str) -> Result<ServerSentEvent<T>, serde_json::Error> {
+        let mut id = None;
+        let mut event = None;
+        let mut retry = None;
+        let mut comment = None;
+        let mut data = None;
+
+        for line in s.lines() {
+            if line.starts_with("id:") {
+                id = Some(line["id:".len()..].trim().to_string());
+            } else if line.starts_with("event:") {
+                event = Some(line["event:".len()..].trim().to_string());
+            } else if line.starts_with("retry:") {
+                retry = line["retry:".len()..].trim().parse::<usize>().ok();
+            } else if line.starts_with(":") {
+                comment = Some(line[":".len()..].trim().to_string());
+            } else if line.starts_with("data:") {
+                let data_str = line["data:".len()..].trim().to_string();
+                data = Some(serde_json::from_str(&data_str)?);
+            }
+        }
+
+        Ok(ServerSentEvent {
+            id,
+            event,
+            retry,
+            comment,
+            data,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+    use serde::Deserialize;
+
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct Data {
+        name: String,
+    }
+
+    #[rstest]
+    #[case("id: 42", ServerSentEvent { id: Some("42".to_string()), event: None, retry: None, comment: None, data: None, })]
+    #[case("event: disconnect", ServerSentEvent { id: None, event: Some("disconnect".to_string()), retry: None, comment: None, data: None, })]
+    #[case("retry: 1337", ServerSentEvent { id: None, event: None, retry: Some(1337), comment: None, data: None, })]
+    #[case("retry: yes", ServerSentEvent { id: None, event: None, retry: None, comment: None, data: None, })]
+    #[case(": hi", ServerSentEvent { id: None, event: None, retry: None, comment: Some("hi".to_string()), data: None, })]
+    #[case(r#"data: { "name": "Johan" } "#, ServerSentEvent { id: None, event: None, retry: None, comment: None, data: Some(Data { name: "Johan".to_string(), }), })]
+    fn deserializes_a_single_field(#[case] data: &str, #[case] expected: ServerSentEvent<Data>) -> Result<(), serde_json::Error> {
+        let result: ServerSentEvent<Data> = ServerSentEvent::from_str(data)?;
+
+        assert_eq!(result, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn deserializes_all_fields() -> Result<(), serde_json::Error> {
+        let data = "id: 42\nevent: disconnect\nretry: 1337\n: hi\ndata: { \"name\": \"Johan\" }";
+
+        let result: ServerSentEvent<Data> = ServerSentEvent::from_str(data)?;
+
+        assert_eq!(
+            result,
+            ServerSentEvent {
+                id: Some("42".to_string()),
+                event: Some("disconnect".to_string()),
+                retry: Some(1337),
+                comment: Some("hi".to_string()),
+                data: Some(Data { name: "Johan".to_string() }),
+            }
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize_fails_if_data_deserialization_fails() -> Result<(), serde_json::Error> {
+        let data = "data: no json";
+
+        let result = ServerSentEvent::<Data>::from_str(data);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "expected ident at line 1 column 2");
+        Ok(())
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,6 +1,6 @@
 use crate::domain::device::Device;
 use crate::domain::events::Event;
-use crate::domain::property::{BooleanProperty, NumberProperty};
+use crate::domain::property::{BooleanProperty, ColorProperty, NumberProperty, Property};
 use crate::property_changed_reducer::reduce_property_changed_event;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -61,6 +61,13 @@ impl Store {
                 Event::NumberPropertyChanged { device_id, property_id, value } => {
                     reduce_property_changed_event(&mut self.devices.clone(), &device_id.clone(), &property_id.clone(), move |property: &mut NumberProperty| {
                         property.set_value(value).map(|_| ())
+                    })
+                    .await
+                    .unwrap_or_default();
+                }
+                Event::ColorPropertyChanged { device_id, property_id, xy, gamut } => {
+                    reduce_property_changed_event(&mut self.devices.clone(), &device_id, &property_id, |property: &mut ColorProperty| {
+                        property.set_value(xy, gamut).map(|_| ())
                     })
                     .await
                     .unwrap_or_default();

--- a/src/store.rs
+++ b/src/store.rs
@@ -51,28 +51,17 @@ impl Store {
 
                     self.notifier_tx.send(self.devices.clone()).unwrap_or_default();
                 }
-                Event::BooleanPropertyChanged {
-                    device_id,
-                    property_id,
-                    value,
-                } => {
+                Event::BooleanPropertyChanged { device_id, property_id, value } => {
                     reduce_property_changed_event(&mut self.devices.clone(), &device_id, &property_id, |property: &mut BooleanProperty| {
                         property.set_value(value).map(|_| ())
                     })
                     .await
                     .unwrap_or_default();
                 }
-                Event::NumberPropertyChanged {
-                    device_id,
-                    property_id,
-                    value,
-                } => {
-                    reduce_property_changed_event(
-                        &mut self.devices.clone(),
-                        &device_id.clone(),
-                        &property_id.clone(),
-                        move |property: &mut NumberProperty| property.set_value(value).map(|_| ()),
-                    )
+                Event::NumberPropertyChanged { device_id, property_id, value } => {
+                    reduce_property_changed_event(&mut self.devices.clone(), &device_id.clone(), &property_id.clone(), move |property: &mut NumberProperty| {
+                        property.set_value(value).map(|_| ())
+                    })
                     .await
                     .unwrap_or_default();
                 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -53,21 +53,21 @@ impl Store {
                 }
                 Event::BooleanPropertyChanged { device_id, property_id, value } => {
                     reduce_property_changed_event(&mut self.devices.clone(), &device_id, &property_id, |property: &mut BooleanProperty| {
-                        property.set_value(value).map(|_| ())
+                        property.set_value(value)
                     })
                     .await
                     .unwrap_or_default();
                 }
                 Event::NumberPropertyChanged { device_id, property_id, value } => {
                     reduce_property_changed_event(&mut self.devices.clone(), &device_id.clone(), &property_id.clone(), move |property: &mut NumberProperty| {
-                        property.set_value(value).map(|_| ())
+                        property.set_value(value)
                     })
                     .await
                     .unwrap_or_default();
                 }
                 Event::ColorPropertyChanged { device_id, property_id, xy, gamut } => {
                     reduce_property_changed_event(&mut self.devices.clone(), &device_id, &property_id, |property: &mut ColorProperty| {
-                        property.set_value(xy, gamut).map(|_| ())
+                        property.set_value(xy, gamut)
                     })
                     .await
                     .unwrap_or_default();

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,6 +1,6 @@
 use crate::domain::device::Device;
 use crate::domain::events::Event;
-use crate::domain::property::{BooleanProperty, ColorProperty, NumberProperty, Property};
+use crate::domain::property::{BooleanProperty, ColorProperty, NumberProperty};
 use crate::property_changed_reducer::reduce_property_changed_event;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,14 +1,13 @@
 use crate::domain::device::Device;
 use crate::domain::events::Event;
-use crate::domain::property::{BooleanProperty, NumberProperty, Property, PropertyError};
+use crate::domain::property::{BooleanProperty, NumberProperty};
 use crate::property_changed_reducer::reduce_property_changed_event;
-use std::any::type_name;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::watch::{Receiver as WatchReceiver, Sender as WatchSender};
 use tokio::sync::{RwLock, watch};
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, info, instrument};
 
 pub type DeviceMap = Arc<RwLock<HashMap<String, Device>>>;
 
@@ -60,7 +59,8 @@ impl Store {
                     reduce_property_changed_event(&mut self.devices.clone(), &device_id, &property_id, |property: &mut BooleanProperty| {
                         property.set_value(value).map(|_| ())
                     })
-                    .await;
+                    .await
+                    .unwrap_or_default();
                 }
                 Event::NumberPropertyChanged {
                     device_id,
@@ -73,7 +73,8 @@ impl Store {
                         &property_id.clone(),
                         move |property: &mut NumberProperty| property.set_value(value).map(|_| ()),
                     )
-                    .await;
+                    .await
+                    .unwrap_or_default();
                 }
             }
         }


### PR DESCRIPTION
- Allow overriding the default config file with a local file
- Rename observer to discoverer
- Introduce an observer that emits events when properties of a device change
- Update the store with property changes
