### PR TITLE
Set color property value

### DIFF
--- a/docs/hue/Hue RGB to xy color conversion.md
+++ b/docs/hue/Hue RGB to xy color conversion.md
@@ -1,0 +1,439 @@
+#Application Design note - Color conversion
+##Color conversion formulas RGB to xy and back
+This document describes the conversion between RGB and xy. It is important to differentiate between the various light
+types, because they do not all support the same color gamut. For example, the hue bulbs are very good at showing nice
+whites, while the LivingColors are generally a bit better at colors, like green and cyan.
+
+Our implementations of these functions are contained in the PHUtility class in our GitHub repo for the Hue
+SDK (https://github.com/PhilipsHue/PhilipsHueSDKiOS). You can see source code of our Objective-C iOS implementation of
+these transformations in the last part of this document.
+
+The method signature for converting from xy values and brightness to a color is:
+
+    + (UIColor *)colorFromXY:(CGPoint)xy forModel:(NSString*)model
+
+The method signature for converting from a color to xy and brightness values:
+
+    + (CGPoint)calculateXY:(UIColor *)color forModel:(NSString*)model
+
+The color to xy/brightness does not return a value, instead takes two pointers to variables which it will change to the
+appropriate values.
+
+The model parameter of both methods is the modelNumber value of a PHLight object. The advantage of this model being
+settable is that you can decide if you want to limit the color of all lights to a certain model, or that every light
+should do the colors within its own range.
+
+Current Philips lights have a color gamut defined by 3 points, making it a triangle.
+
+For the hue bulb the corners of the triangle are:
+
+    Red: 0.675, 0.322
+    Green: 0.4091, 0.518
+    Blue: 0.167, 0.04
+
+For LivingColors Bloom, Aura and Iris the triangle corners are:
+
+    Red: 0.704, 0.296
+    Green: 0.2151, 0.7106
+    Blue: 0.138, 0.08
+
+If you have light which is not one of those, you should use:
+
+    Red: 1.0, 0
+    Green: 0.0, 1.0
+    Blue: 0.0, 0.0
+
+##Color(RGB) to xy
+We start with the color to xy conversion, which we will do in a couple of steps:
+
+1. Get the RGB values from your color object and convert them to be between 0 and 1.
+   So the RGB color (255, 0, 100) becomes (1.0, 0.0, 0.39)
+2. Apply a gamma correction to the RGB values, which makes the color more vivid and more the like the color displayed on
+   the screen of your device.
+   This gamma correction is also applied to the screen of your computer or phone, thus we need this to create the same
+   color on the light as on screen.
+   This is done by the following formulas:
+
+   float red = (red > 0.04045f) ? pow((red + 0.055f) / (1.0f + 0.055f), 2.4f) : (red / 12.92f);
+   float green = (green > 0.04045f) ? pow((green + 0.055f) / (1.0f + 0.055f), 2.4f) : (green / 12.92f);
+   float blue = (blue > 0.04045f) ? pow((blue + 0.055f) / (1.0f + 0.055f), 2.4f) : (blue / 12.92f);
+
+3. Convert the RGB values to XYZ using the Wide RGB D65 conversion formula
+   The formulas used:
+
+   float X = red * 0.649926f + green * 0.103455f + blue * 0.197109f;
+   float Y = red * 0.234327f + green * 0.743075f + blue * 0.022598f;
+   float Z = red * 0.0000000f + green * 0.053077f + blue * 1.035763f;
+
+4. Calculate the xy values from the XYZ values
+
+   float x = X / (X + Y + Z); float y = Y / (X + Y + Z);
+
+5. Check if the found xy value is within the color gamut of the light, if not continue with step 6, otherwise step 7
+   When we sent a value which the light is not capable of, the resulting color might not be optimal. Therefor we try to
+   only sent values which are inside the color gamut of the selected light.
+
+6. Calculate the closest point on the color gamut triangle and use that as xy value
+   The closest value is calculated by making a perpendicular line to one of the lines the triangle consists of and when
+   it is then still not inside the triangle, we choose the closest corner point of the triangle.
+7. Use the Y value of XYZ as brightness
+   The Y value indicates the brightness of the converted color.
+
+##xy to color(RGB)
+The xy to color conversion is almost the same, but in reverse order.
+
+1. Check if the xy value is within the color gamut of the lamp, if not continue with step 2, otherwise step 3
+   We do this to calculate the most accurate color the given light can actually do.
+2. Calculate the closest point on the color gamut triangle and use that as xy value
+   See step 6 of color to xy.
+3. Calculate XYZ values
+   Convert using the following formulas:
+
+   float x = x; // the given x value
+   float y = y; // the given y value
+   float z = 1.0f - x - y;
+   float Y = brightness; // The given brightness value
+   float X = (Y / y) * x;  
+   float Z = (Y / y) * z;
+
+4. Convert to RGB using Wide RGB D65 conversion
+
+   float r = X * 1.612f - Y * 0.203f - Z * 0.302f;
+   float g = -X * 0.509f + Y * 1.412f + Z * 0.066f;
+   float b = X * 0.026f - Y * 0.072f + Z * 0.962f;
+
+5. Apply reverse gamma correction
+
+   r = r <= 0.0031308f ? 12.92f * r : (1.0f + 0.055f) * pow(r, (1.0f / 2.4f)) - 0.055f;
+   g = g <= 0.0031308f ? 12.92f * g : (1.0f + 0.055f) * pow(g, (1.0f / 2.4f)) - 0.055f;
+   b = b <= 0.0031308f ? 12.92f * b : (1.0f + 0.055f) * pow(b, (1.0f / 2.4f)) - 0.055f;
+
+6. Convert the RGB values to your color object
+   The rgb values from the above formulas are between 0.0 and 1.0.
+
+##Code Examples
+The following code is an extract from the relevant methods in the iOS SDK. It is provided on an as is basis to help you
+create your own versions of the color conversion utilities.
+Note that the UIColor class contains a method to obtain Hue/Saturation
+values http://developer.apple.com/library/ios/#documentation/UIKit/Reference/UIColor_Class/Reference/Reference.html
+
+    + (UIColor *)colorFromXY:(CGPoint)xy forModel:(NSString*)model {        
+        NSArray *colorPoints = [self colorPointsForModel:model];
+        BOOL inReachOfLamps = [self checkPointInLampsReach:xy withColorPoints:colorPoints];
+        
+        if (!inReachOfLamps) {
+            //It seems the colour is out of reach
+            //let's find the closest colour we can produce with our lamp and send this XY value out.
+            
+            //Find the closest point on each line in the triangle.
+            CGPoint pAB =[self getClosestPointToPoints:[self getPointFromValue:[colorPoints objectAtIndex:cptRED]] point2:[self getPointFromValue:[colorPoints objectAtIndex:cptGREEN]] point3:xy];
+            CGPoint pAC = [self getClosestPointToPoints:[self getPointFromValue:[colorPoints objectAtIndex:cptBLUE]] point2:[self getPointFromValue:[colorPoints objectAtIndex:cptRED]] point3:xy];
+            CGPoint pBC = [self getClosestPointToPoints:[self getPointFromValue:[colorPoints objectAtIndex:cptGREEN]] point2:[self getPointFromValue:[colorPoints objectAtIndex:cptBLUE]] point3:xy];
+            
+            //Get the distances per point and see which point is closer to our Point.
+            float dAB = [self getDistanceBetweenTwoPoints:xy point2:pAB];
+            float dAC = [self getDistanceBetweenTwoPoints:xy point2:pAC];
+            float dBC = [self getDistanceBetweenTwoPoints:xy point2:pBC];
+            
+            float lowest = dAB;
+            CGPoint closestPoint = pAB;
+            
+            if (dAC < lowest) {
+                lowest = dAC;
+                closestPoint = pAC;
+            }
+            if (dBC < lowest) {
+                lowest = dBC;
+                closestPoint = pBC;
+            }
+            
+            //Change the xy value to a value which is within the reach of the lamp.
+            xy.x = closestPoint.x;
+            xy.y = closestPoint.y;
+        }
+        
+        float x = xy.x;
+        float y = xy.y;
+        float z = 1.0f - x - y;
+        
+        float Y = 1.0f;
+        float X = (Y / y) * x;
+        float Z = (Y / y) * z;
+        
+        // sRGB D65 conversion
+        float r = X  * 3.2406f - Y * 1.5372f - Z * 0.4986f;
+        float g = -X * 0.9689f + Y * 1.8758f + Z * 0.0415f;
+        float b = X  * 0.0557f - Y * 0.2040f + Z * 1.0570f;
+        
+        if (r > b && r > g && r > 1.0f) {
+            // red is too big
+            g = g / r;
+            b = b / r;
+            r = 1.0f;
+        }
+        else if (g > b && g > r && g > 1.0f) {
+            // green is too big
+            r = r / g;
+            b = b / g;
+            g = 1.0f;
+        }
+        else if (b > r && b > g && b > 1.0f) {
+            // blue is too big
+            r = r / b;
+            g = g / b;
+            b = 1.0f;
+        }
+        
+        // Apply gamma correction
+        r = r <= 0.0031308f ? 12.92f * r : (1.0f + 0.055f) * pow(r, (1.0f / 2.4f)) - 0.055f;
+        g = g <= 0.0031308f ? 12.92f * g : (1.0f + 0.055f) * pow(g, (1.0f / 2.4f)) - 0.055f;
+        b = b <= 0.0031308f ? 12.92f * b : (1.0f + 0.055f) * pow(b, (1.0f / 2.4f)) - 0.055f;
+        
+        if (r > b && r > g) {
+            // red is biggest
+            if (r > 1.0f) {
+                g = g / r;
+                b = b / r;
+                r = 1.0f;
+            }
+        }
+        else if (g > b && g > r) {
+            // green is biggest
+            if (g > 1.0f) {
+                r = r / g;
+                b = b / g;
+                g = 1.0f;
+            }
+        }
+        else if (b > r && b > g) {
+            // blue is biggest
+            if (b > 1.0f) {
+                r = r / b;
+                g = g / b;
+                b = 1.0f;
+            }
+        }
+
+        return [UIColor colorWithRed:r green:g blue:b alpha:1.0f];
+    }
+    
+    + (NSArray *)colorPointsForModel:(NSString*)model {
+        NSMutableArray *colorPoints = [NSMutableArray array];
+        
+        NSArray *hueBulbs = [NSArray arrayWithObjects:@"LCT001" /* Hue A19 */,
+                             @"LCT002" /* Hue BR30 */,
+                             @"LCT003" /* Hue GU10 */, nil];
+        NSArray *livingColors = [NSArray arrayWithObjects:  @"LLC001" /* Monet, Renoir, Mondriaan (gen II) */,
+                                 @"LLC005" /* Bloom (gen II) */,
+                                 @"LLC006" /* Iris (gen III) */,
+                                 @"LLC007" /* Bloom, Aura (gen III) */,
+                                 @"LLC011" /* Hue Bloom */,
+                                 @"LLC012" /* Hue Bloom */,
+                                 @"LLC013" /* Storylight */,
+                                 @"LST001" /* Light Strips */, nil];
+        if ([hueBulbs containsObject:model]) {
+            // Hue bulbs color gamut triangle
+            [colorPoints addObject:[self getValueFromPoint:CGPointMake(0.674F, 0.322F)]];     // Red
+            [colorPoints addObject:[self getValueFromPoint:CGPointMake(0.408F, 0.517F)]];     // Green
+            [colorPoints addObject:[self getValueFromPoint:CGPointMake(0.168F, 0.041F)]];     // Blue
+            
+        }
+        else if ([livingColors containsObject:model]) {
+            // LivingColors color gamut triangle
+            [colorPoints addObject:[self getValueFromPoint:CGPointMake(0.703F, 0.296F)]];     // Red
+            [colorPoints addObject:[self getValueFromPoint:CGPointMake(0.214F, 0.709F)]];     // Green
+            [colorPoints addObject:[self getValueFromPoint:CGPointMake(0.139F, 0.081F)]];     // Blue
+        }
+        else {
+            // Default construct triangle wich contains all values
+            [colorPoints addObject:[self getValueFromPoint:CGPointMake(1.0F, 0.0F)]];         // Red
+            [colorPoints addObject:[self getValueFromPoint:CGPointMake(0.0F, 1.0F)]];         // Green
+            [colorPoints addObject:[self getValueFromPoint:CGPointMake(0.0F, 0.0F)]];         // Blue
+        }
+        
+        return colorPoints;
+    }
+    
+    + (CGPoint)calculateXY:(UIColor *)color forModel:(NSString*)model {
+    	CGColorRef cgColor = [color CGColor];
+            
+        const CGFloat *components = CGColorGetComponents(cgColor);
+        long numberOfComponents = CGColorGetNumberOfComponents(cgColor);
+            
+        // Default to white
+        CGFloat red = 1.0f;
+        CGFloat green = 1.0f;
+        CGFloat blue = 1.0f;
+           
+        if (numberOfComponents == 4) {
+            // Full color
+            red = components[0];
+            green = components[1];
+            blue = components[2];
+        }
+        else if (numberOfComponents == 2) {
+            // Greyscale color
+            red = green = blue = components[0];
+        }
+            
+        // Apply gamma correction
+        float r = (red   > 0.04045f) ? pow((red   + 0.055f) / (1.0f + 0.055f), 2.4f) : (red   / 12.92f);
+        float g = (green > 0.04045f) ? pow((green + 0.055f) / (1.0f + 0.055f), 2.4f) : (green / 12.92f);
+        float b = (blue  > 0.04045f) ? pow((blue  + 0.055f) / (1.0f + 0.055f), 2.4f) : (blue  / 12.92f);
+            
+        // Wide gamut conversion D65
+        float X = r * 0.649926f + g * 0.103455f + b * 0.197109f;
+        float Y = r * 0.234327f + g * 0.743075f + b * 0.022598f;
+        float Z = r * 0.0000000f + g * 0.053077f + b * 1.035763f;
+            
+        float cx = X / (X + Y + Z);
+        float cy = Y / (X + Y + Z);
+           
+        if (isnan(cx)) {
+            cx = 0.0f;
+        }
+            
+        if (isnan(cy)) {
+            cy = 0.0f;
+        }
+            
+        //Check if the given XY value is within the colourreach of our lamps.
+           
+        CGPoint xyPoint =  CGPointMake(cx,cy);
+        NSArray *colorPoints = [self colorPointsForModel:model];
+        BOOL inReachOfLamps = [self checkPointInLampsReach:xyPoint withColorPoints:colorPoints];
+            
+        if (!inReachOfLamps) {
+       	    //It seems the colour is out of reach
+            //let's find the closest colour we can produce with our lamp and send this XY value out.
+                
+            //Find the closest point on each line in the triangle.
+            CGPoint pAB =[self getClosestPointToPoints:[self getPointFromValue:[colorPoints objectAtIndex:cptRED]] point2:[self getPointFromValue:[colorPoints objectAtIndex:cptGREEN]] point3:xyPoint];
+            CGPoint pAC = [self getClosestPointToPoints:[self getPointFromValue:[colorPoints objectAtIndex:cptBLUE]] point2:[self getPointFromValue:[colorPoints objectAtIndex:cptRED]] point3:xyPoint];
+            CGPoint pBC = [self getClosestPointToPoints:[self getPointFromValue:[colorPoints objectAtIndex:cptGREEN]] point2:[self getPointFromValue:[colorPoints objectAtIndex:cptBLUE]] point3:xyPoint];
+                
+            //Get the distances per point and see which point is closer to our Point.
+            float dAB = [self getDistanceBetweenTwoPoints:xyPoint point2:pAB];
+            float dAC = [self getDistanceBetweenTwoPoints:xyPoint point2:pAC];
+            float dBC = [self getDistanceBetweenTwoPoints:xyPoint point2:pBC];
+                
+            float lowest = dAB;
+            CGPoint closestPoint = pAB;
+                
+            if (dAC < lowest) {
+                lowest = dAC;
+                closestPoint = pAC;
+            }
+            if (dBC < lowest) {
+                lowest = dBC;
+                closestPoint = pBC;
+            }
+              
+            //Change the xy value to a value which is within the reach of the lamp.
+            cx = closestPoint.x;
+            cy = closestPoint.y;
+        }
+           
+        return CGPointMake(cx, cy);
+    }
+        
+    /**
+     * Calculates crossProduct of two 2D vectors / points.
+     *
+     * @param p1 first point used as vector
+     * @param p2 second point used as vector
+     * @return crossProduct of vectors
+     */
+    + (float)crossProduct:(CGPoint)p1 point2:(CGPoint)p2 {
+        return (p1.x * p2.y - p1.y * p2.x);
+    }
+        
+    /**
+     * Find the closest point on a line.
+     * This point will be within reach of the lamp.
+     *
+     * @param A the point where the line starts
+     * @param B the point where the line ends
+     * @param P the point which is close to a line.
+     * @return the point which is on the line.
+     */
+    + (CGPoint)getClosestPointToPoints:(CGPoint)A point2:(CGPoint)B point3:(CGPoint)P {
+        CGPoint AP = CGPointMake(P.x - A.x, P.y - A.y);
+        CGPoint AB = CGPointMake(B.x - A.x, B.y - A.y);
+        float ab2 = AB.x * AB.x + AB.y * AB.y;
+        float ap_ab = AP.x * AB.x + AP.y * AB.y;
+            
+        float t = ap_ab / ab2;
+          
+        if (t < 0.0f) {
+            t = 0.0f;
+        }
+        else if (t > 1.0f) {
+            t = 1.0f;
+        }
+            
+        CGPoint newPoint = CGPointMake(A.x + AB.x * t, A.y + AB.y * t);
+        return newPoint;
+    }
+        
+    /**
+     * Find the distance between two points.
+     *
+     * @param one
+     * @param two
+     * @return the distance between point one and two
+     */
+    + (float)getDistanceBetweenTwoPoints:(CGPoint)one point2:(CGPoint)two {
+        float dx = one.x - two.x; // horizontal difference
+        float dy = one.y - two.y; // vertical difference
+        float dist = sqrt(dx * dx + dy * dy);
+            
+        return dist;
+    }
+        
+    /**
+     * Method to see if the given XY value is within the reach of the lamps.
+     *
+     * @param p the point containing the X,Y value
+     * @return true if within reach, false otherwise.
+     */
+    + (BOOL)checkPointInLampsReach:(CGPoint)p withColorPoints:(NSArray*)colorPoints {
+        CGPoint red =   [self getPointFromValue:[colorPoints objectAtIndex:cptRED]];
+        CGPoint green = [self getPointFromValue:[colorPoints objectAtIndex:cptGREEN]];
+        CGPoint blue =  [self getPointFromValue:[colorPoints objectAtIndex:cptBLUE]];
+           
+        CGPoint v1 = CGPointMake(green.x - red.x, green.y - red.y);
+        CGPoint v2 = CGPointMake(blue.x - red.x, blue.y - red.y);
+            
+        CGPoint q = CGPointMake(p.x - red.x, p.y - red.y);
+            
+        float s = [self crossProduct:q point2:v2] / [self crossProduct:v1 point2:v2];
+        float t = [self crossProduct:v1 point2:q] / [self crossProduct:v1 point2:v2];
+            
+        if ( (s >= 0.0f) && (t >= 0.0f) && (s + t <= 1.0f)) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+##Further Information
+The following links provide further useful related information
+
+sRGB:
+
+http://en.wikipedia.org/wiki/Srgb
+
+A Review of RGB Color Spaces:
+
+http://www.babelcolor.com/download/A%20review%20of%20RGB%20color%20spaces.pdf
+
+Useful color equations:
+http://www.brucelindbloom.com/
+
+
+
+
+
+

--- a/src/domain/color.rs
+++ b/src/domain/color.rs
@@ -1,0 +1,234 @@
+use crate::domain::color::Color::{CIE_xyY, Hex, RGB};
+use crate::domain::property::CartesianCoordinate;
+use thiserror::Error;
+
+#[derive(PartialEq, Clone, Debug)]
+pub enum Color {
+    RGB(u8, u8, u8),
+    Hex(String),
+    #[allow(non_camel_case_types)]
+    CIE_xyY {
+        xy: CartesianCoordinate,
+        brightness: f64,
+    },
+}
+
+impl Color {
+    pub fn to_hex(self) -> Color {
+        match self {
+            RGB(r, g, b) => Hex(format!("#{:02x}{:02x}{:02x}", r, g, b)),
+            Hex(_) => self,
+            CIE_xyY { xy, brightness } => {
+                let (r, g, b) = xyY_to_rgb(&xy, brightness);
+                Hex(format!("#{:02x}{:02x}{:02x}", r, g, b))
+            }
+        }
+    }
+
+    pub fn to_rgb(self) -> Result<Color, ColorConversionError> {
+        match self {
+            RGB(_, _, _) => Ok(self),
+            Hex(value) => {
+                let (r, g, b) = hex_to_rgb(&value)?;
+                Ok(RGB(r, g, b))
+            }
+            CIE_xyY { xy, brightness } => {
+                let (r, g, b) = xyY_to_rgb(&xy, brightness);
+                Ok(RGB(r, g, b))
+            }
+        }
+    }
+
+    #[allow(non_snake_case)]
+    pub fn to_cie_xyY(self) -> Result<Color, ColorConversionError> {
+        match self {
+            RGB(r, g, b) => Ok(rgb_to_xyY(r, g, b)),
+            Hex(value) => {
+                let (r, g, b) = hex_to_rgb(&value)?;
+                Ok(rgb_to_xyY(r, g, b))
+            }
+            CIE_xyY { .. } => Ok(self),
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ColorConversionError {
+    #[error("invalid hexadecimal value '{0}'")]
+    InvalidHexFormat(String),
+}
+
+#[allow(non_snake_case)]
+fn hex_to_rgb(hex: &str) -> Result<(u8, u8, u8), ColorConversionError> {
+    let hex = hex.trim_start_matches('#');
+
+    let red = u8::from_str_radix(&hex[0..2], 16).map_err(|_| ColorConversionError::InvalidHexFormat(hex.to_string()))?;
+    let green = u8::from_str_radix(&hex[2..4], 16).map_err(|_| ColorConversionError::InvalidHexFormat(hex.to_string()))?;
+    let blue = u8::from_str_radix(&hex[4..6], 16).map_err(|_| ColorConversionError::InvalidHexFormat(hex.to_string()))?;
+
+    Ok((red, green, blue))
+}
+
+#[allow(non_snake_case)]
+fn rgb_to_xyY(red: u8, green: u8, blue: u8) -> Color {
+    // Convert to linear RGB
+    let r = gamma_correct(red as f64 / 255.0);
+    let g = gamma_correct(green as f64 / 255.0);
+    let b = gamma_correct(blue as f64 / 255.0);
+
+    // Convert to XYZ using sRGB D65
+    let x = r * 0.4124 + g * 0.3576 + b * 0.1805;
+    let y = r * 0.2126 + g * 0.7152 + b * 0.0722; // this is luminance
+    let z = r * 0.0193 + g * 0.1192 + b * 0.9505;
+
+    let sum = x + y + z;
+    let (cx, cy) = if sum == 0.0 { (0.0, 0.0) } else { (x / sum, y / sum) };
+
+    CIE_xyY {
+        xy: CartesianCoordinate::new(cx, cy),
+        brightness: y,
+    }
+}
+
+fn gamma_correct(channel: f64) -> f64 {
+    if channel > 0.04045 { ((channel + 0.055) / 1.055).powf(2.4) } else { channel / 12.92 }
+}
+
+/// Converts xy + Y (luminance) back to gamma-corrected sRGB (0–255).
+/// Result is lossless as long as the same gamma and transform are used.
+#[allow(non_snake_case)]
+fn xyY_to_rgb(xy: &CartesianCoordinate, brightness: f64) -> (u8, u8, u8) {
+    let x = xy.x();
+    let y = xy.y();
+    let z = 1.0 - x - y;
+
+    let X = (brightness / y) * x;
+    let Y = brightness;
+    let Z = (brightness / y) * z;
+
+    // Convert back to linear sRGB
+    let r_lin = X * 3.2406 + Y * -1.5372 + Z * -0.4986;
+    let g_lin = X * -0.9689 + Y * 1.8758 + Z * 0.0415;
+    let b_lin = X * 0.0557 + Y * -0.2040 + Z * 1.0570;
+
+    // Clamp and gamma-correct
+    let r = gamma_correct_rev(r_lin.max(0.0).min(1.0));
+    let g = gamma_correct_rev(g_lin.max(0.0).min(1.0));
+    let b = gamma_correct_rev(b_lin.max(0.0).min(1.0));
+
+    ((r * 255.0).round() as u8, (g * 255.0).round() as u8, (b * 255.0).round() as u8)
+}
+
+fn gamma_correct_rev(channel: f64) -> f64 {
+    if channel <= 0.0031308 {
+        channel * 12.92
+    } else {
+        1.055 * channel.powf(1.0 / 2.4) - 0.055
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod to_hex {
+        use super::*;
+
+        #[test]
+        fn from_rgb() {
+            assert_eq!(RGB(255, 0, 255).to_hex(), Hex("#ff00ff".to_string()));
+            assert_eq!(RGB(50, 100, 150).to_hex(), Hex("#326496".to_string()));
+        }
+
+        #[test]
+        fn from_hex() {
+            assert_eq!(Hex("#ff00ff".to_string()).to_hex(), Hex("#ff00ff".to_string()));
+            assert_eq!(Hex("#326496".to_string()).to_hex(), Hex("#326496".to_string()));
+        }
+
+        #[test]
+        #[allow(non_snake_case)]
+        fn from_cie_xyY() {
+            assert_eq!(
+                CIE_xyY {
+                    xy: CartesianCoordinate::new(0.3209201623815967, 0.15415426251691475),
+                    brightness: 0.2848
+                }
+                .to_hex(),
+                Hex("#ff00ff".to_string())
+            );
+        }
+    }
+
+    mod to_rgb {
+        use super::*;
+
+        #[test]
+        fn from_rgb() {
+            assert_eq!(RGB(255, 0, 255).to_rgb().unwrap(), RGB(255, 0, 255));
+        }
+
+        #[test]
+        fn from_hex() {
+            assert_eq!(Hex("#ff00ff".to_string()).to_rgb().unwrap(), RGB(255, 0, 255));
+            assert_eq!(Hex("#326496".to_string()).to_rgb().unwrap(), RGB(50, 100, 150));
+        }
+
+        #[test]
+        #[allow(non_snake_case)]
+        fn from_cie_xyY() {
+            assert_eq!(
+                CIE_xyY {
+                    xy: CartesianCoordinate::new(0.32092016238159676, 0.15415426251691475),
+                    brightness: 0.2848
+                }
+                .to_rgb()
+                .unwrap(),
+                RGB(255, 0, 255)
+            );
+        }
+    }
+
+    mod to_cie_xyy {
+        use super::*;
+
+        #[test]
+        fn from_rgb() {
+            assert_eq!(
+                RGB(255, 0, 255).to_cie_xyY().unwrap(),
+                CIE_xyY {
+                    xy: CartesianCoordinate::new(0.32092016238159676, 0.15415426251691475),
+                    brightness: 0.2848
+                }
+            );
+        }
+
+        #[test]
+        fn from_hex() {
+            assert_eq!(
+                Hex("#ff00ff".to_string()).to_cie_xyY().unwrap(),
+                CIE_xyY {
+                    xy: CartesianCoordinate::new(0.32092016238159676, 0.15415426251691475),
+                    brightness: 0.2848
+                }
+            );
+        }
+
+        #[test]
+        #[allow(non_snake_case)]
+        fn from_cie_xyY() {
+            assert_eq!(
+                CIE_xyY {
+                    xy: CartesianCoordinate::new(0.3209201623815967, 0.15415426251691475),
+                    brightness: 0.2848
+                }
+                .to_cie_xyY()
+                .unwrap(),
+                CIE_xyY {
+                    xy: CartesianCoordinate::new(0.3209201623815967, 0.15415426251691475),
+                    brightness: 0.2848
+                }
+            );
+        }
+    }
+}

--- a/src/domain/events.rs
+++ b/src/domain/events.rs
@@ -13,7 +13,7 @@ pub enum Event {
     NumberPropertyChanged {
         device_id: String,
         property_id: String,
-        value: Number,
+        value: Option<Number>,
     },
     ColorPropertyChanged {
         device_id: String,

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,3 +1,4 @@
+pub mod color;
 pub mod commands;
 pub mod controller;
 pub mod controller_registry;

--- a/src/domain/number.rs
+++ b/src/domain/number.rs
@@ -10,6 +10,14 @@ pub enum Number {
 }
 
 impl Number {
+    pub fn as_u64(&self) -> Option<u64> {
+        match self {
+            Number::PositiveInt(value) => Some(value.clone()),
+            Number::NegativeInt(value) if value.is_positive() => Some(value.clone() as u64),
+            _ => None,
+        }
+    }
+
     pub fn as_f64(&self) -> Option<f64> {
         match self {
             Number::PositiveInt(n) => Some(n.clone() as f64),

--- a/src/domain/number.rs
+++ b/src/domain/number.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::fmt::Display;
 use std::ops::{Add, Sub};
 
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum Number {
     PositiveInt(u64),
     NegativeInt(i64),

--- a/src/domain/property/color_property.rs
+++ b/src/domain/property/color_property.rs
@@ -35,6 +35,10 @@ impl ColorProperty {
 
         Ok(())
     }
+
+    pub fn gamut(&self) -> Option<&Gamut> {
+        self.gamut.as_ref()
+    }
 }
 
 impl Property for ColorProperty {
@@ -105,5 +109,17 @@ pub struct Gamut {
 impl Gamut {
     pub fn new(red: CartesianCoordinate, green: CartesianCoordinate, blue: CartesianCoordinate) -> Self {
         Gamut { red, green, blue }
+    }
+
+    pub fn red(&self) -> &CartesianCoordinate {
+        &self.red
+    }
+
+    pub fn green(&self) -> &CartesianCoordinate {
+        &self.green
+    }
+
+    pub fn blue(&self) -> &CartesianCoordinate {
+        &self.blue
     }
 }

--- a/src/domain/property/color_property.rs
+++ b/src/domain/property/color_property.rs
@@ -85,6 +85,14 @@ impl CartesianCoordinate {
     pub fn new(x: f64, y: f64) -> Self {
         CartesianCoordinate { x, y }
     }
+
+    pub fn x(&self) -> f64 {
+        self.x
+    }
+
+    pub fn y(&self) -> f64 {
+        self.y
+    }
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/src/domain/property/number_property.rs
+++ b/src/domain/property/number_property.rs
@@ -10,7 +10,7 @@ pub struct NumberProperty {
     readonly: bool,
     external_id: Option<String>,
     unit: Unit,
-    value: Number,
+    value: Option<Number>,
     minimum: Option<Number>,
     maximum: Option<Number>,
 }
@@ -21,14 +21,14 @@ impl NumberProperty {
     }
 
     pub fn as_u64(&self) -> Option<u64> {
-        match self.value {
+        match self.value? {
             Number::PositiveInt(value) => Some(value),
             Number::NegativeInt(_) | Number::Float(_) => None,
         }
     }
 
     pub fn as_i64(&self) -> Option<i64> {
-        match self.value {
+        match self.value? {
             Number::PositiveInt(n) => {
                 if n <= i64::MAX as u64 {
                     Some(n as i64)
@@ -42,14 +42,14 @@ impl NumberProperty {
     }
 
     pub fn as_f64(&self) -> Option<f64> {
-        match self.value {
+        match self.value? {
             Number::PositiveInt(n) => Some(n as f64),
             Number::NegativeInt(n) => Some(n as f64),
             Number::Float(n) => Some(n),
         }
     }
 
-    pub fn value(&self) -> Number {
+    pub fn value(&self) -> Option<Number> {
         self.value.clone()
     }
 
@@ -75,7 +75,7 @@ impl NumberProperty {
 
     // This function does not validate the value as the value comes from an observer and the system
     // must be in sync with the observed system.
-    pub fn set_value(&mut self, value: Number) -> Result<(), PropertyError> {
+    pub fn set_value(&mut self, value: Option<Number>) -> Result<(), PropertyError> {
         if self.readonly {
             return Err(PropertyError::ReadOnly);
         }
@@ -110,7 +110,7 @@ impl Property for NumberProperty {
     }
 
     fn value_string(&self) -> String {
-        self.value.to_string()
+        self.value.map(|v| v.to_string()).unwrap_or(String::new())
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -136,7 +136,7 @@ pub struct NumberPropertyBuilder {
     readonly: bool,
     external_id: Option<String>,
     unit: Unit,
-    value: Number,
+    value: Option<Number>,
     minimum: Option<Number>,
     maximum: Option<Number>,
 }
@@ -149,7 +149,7 @@ impl NumberPropertyBuilder {
             readonly,
             external_id: None,
             unit: Unit::Percentage,
-            value: Number::PositiveInt(0),
+            value: Some(Number::PositiveInt(0)),
             minimum: None,
             maximum: None,
         }
@@ -166,21 +166,21 @@ impl NumberPropertyBuilder {
     }
 
     pub fn positive_int(mut self, value: u64, minimum: Option<u64>, maximum: Option<u64>) -> Self {
-        self.value = Number::PositiveInt(value);
+        self.value = Some(Number::PositiveInt(value));
         self.minimum = minimum.map(|v| Number::PositiveInt(v));
         self.maximum = maximum.map(|v| Number::PositiveInt(v));
         self
     }
 
     pub fn negative_int(mut self, value: i64, minimum: Option<i64>, maximum: Option<i64>) -> Self {
-        self.value = Number::NegativeInt(value);
+        self.value = Some(Number::NegativeInt(value));
         self.minimum = minimum.map(|v| Number::NegativeInt(v));
         self.maximum = maximum.map(|v| Number::NegativeInt(v));
         self
     }
 
     pub fn float(mut self, value: f64, minimum: Option<f64>, maximum: Option<f64>) -> Self {
-        self.value = Number::Float(value);
+        self.value = Some(Number::Float(value));
         self.minimum = minimum.map(|v| Number::Float(v));
         self.maximum = maximum.map(|v| Number::Float(v));
         self

--- a/src/flow_engine/expression.rs
+++ b/src/flow_engine/expression.rs
@@ -86,7 +86,7 @@ pub fn evaluate(expression: &Expression, context: &Context) -> Result<Value, Exp
             match property.property_type() {
                 PropertyType::Brightness => {
                     let value = property.as_any().downcast_ref::<NumberProperty>().unwrap();
-                    Ok(Value::Number(value.value()))
+                    Ok(Value::Number(value.value().ok_or_else(|| ExpressionError::NoneValue)?))
                 }
                 PropertyType::Color => Err(ExpressionError::UnsupportedPropertyType(property.property_type())),
                 PropertyType::ColorTemperature => Err(ExpressionError::UnsupportedPropertyType(property.property_type())),
@@ -131,6 +131,8 @@ pub enum ExpressionError {
     UnsupportedPropertyType(PropertyType),
     #[error("unable to compare given Numbers {actual_lhs} and {actual_rhs}")]
     ComparisonFailed { actual_lhs: String, actual_rhs: String },
+    #[error("value is None")]
+    NoneValue,
 }
 
 #[cfg(test)]

--- a/src/flow_engine/property_value.rs
+++ b/src/flow_engine/property_value.rs
@@ -1,4 +1,5 @@
 use crate::domain::Number;
+use crate::domain::color::Color;
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum PropertyValue {
@@ -7,5 +8,5 @@ pub enum PropertyValue {
     SetNumberValue(Number),
     IncrementNumberValue(Number),
     DecrementNumberValue(Number),
-    SetColor(String),
+    SetColor(Color),
 }

--- a/src/flow_engine/property_value.rs
+++ b/src/flow_engine/property_value.rs
@@ -7,4 +7,5 @@ pub enum PropertyValue {
     SetNumberValue(Number),
     IncrementNumberValue(Number),
     DecrementNumberValue(Number),
+    SetColor(String),
 }

--- a/src/flow_loader/color_deserializer.rs
+++ b/src/flow_loader/color_deserializer.rs
@@ -1,0 +1,129 @@
+use crate::domain::color::Color;
+use crate::domain::property::CartesianCoordinate;
+use serde::de::{Error, Unexpected};
+use serde::{Deserialize, Deserializer};
+
+impl<'de> Deserialize<'de> for Color {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum RawColor {
+            Hex(String),
+            Rgb {
+                r: u8,
+                g: u8,
+                b: u8,
+            },
+            XyY {
+                x: f64,
+                y: f64,
+                brightness: f64,
+            },
+            #[allow(non_snake_case)]
+            XyYAlt {
+                x: f64,
+                y: f64,
+                Y: f64,
+            },
+        }
+
+        match RawColor::deserialize(deserializer)? {
+            RawColor::Hex(s) => {
+                let normalized = s.trim_start_matches('#').to_lowercase();
+                if normalized.len() == 6 && normalized.chars().all(|c| c.is_ascii_hexdigit()) {
+                    Ok(Color::Hex(format!("#{}", normalized)))
+                } else {
+                    Err(Error::invalid_value(Unexpected::Str(&s), &"a 6-digit hex color"))
+                }
+            }
+            RawColor::Rgb { r, g, b } => Ok(Color::RGB(r, g, b)),
+            RawColor::XyY { x, y, brightness } => Ok(Color::CIE_xyY {
+                xy: CartesianCoordinate::new(x, y),
+                brightness,
+            }),
+            RawColor::XyYAlt { x, y, Y } => Ok(Color::CIE_xyY {
+                xy: CartesianCoordinate::new(x, y),
+                brightness: Y,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::valid_hex("#000000", Ok(Color::Hex("#000000".to_string())))]
+    #[case::valid_hex_without_hash("000000", Ok(Color::Hex("#000000".to_string())))]
+    #[case::valid_hex_mixed_case("#8A7b4C", Ok(Color::Hex("#8a7b4c".to_string())))]
+    #[case::invalid_hex("#000", Err(Error::custom("invalid value: string \"#000\", expected a 6-digit hex color")))]
+    #[case::invalid_hex("#00000Z", Err(Error::custom("invalid value: string \"#00000Z\", expected a 6-digit hex color")))]
+    fn deserializes_hex_values(#[case] json_value: String, #[case] expected: serde_json::Result<Color>) {
+        let json = format!(r#""{}""#, json_value);
+
+        let response = serde_json::from_str::<Color>(&json);
+
+        // As serde_json::Error does not implement PartialEq, use debug print for comparison
+        assert_eq!(format!("{:#?}", response), format!("{:#?}", expected));
+    }
+
+    #[rstest]
+    #[case(0, 150, 255, Ok(Color::RGB(0, 150, 255)))]
+    fn deserialize_rgb_values(#[case] r: u8, #[case] g: u8, #[case] b: u8, #[case] expected: serde_json::Result<Color>) {
+        let json = format!(
+            r#"{{
+                "r": {},
+                "g": {},
+                "b": {}
+            }}"#,
+            r, g, b
+        );
+
+        let response = serde_json::from_str::<Color>(&json);
+
+        // As serde_json::Error does not implement PartialEq, use debug print for comparison
+        assert_eq!(format!("{:#?}", response), format!("{:#?}", expected));
+    }
+
+    #[rstest]
+    #[case(0.4, 0.3, 0.9, Ok(Color::CIE_xyY { xy: CartesianCoordinate::new(x, y), brightness}))]
+    fn deserialize_xy_brightness_values(#[case] x: f64, #[case] y: f64, #[case] brightness: f64, #[case] expected: serde_json::Result<Color>) {
+        let json = format!(
+            r#"{{
+                "x": {},
+                "y": {},
+                "brightness": {}
+            }}"#,
+            x, y, brightness
+        );
+
+        let response = serde_json::from_str::<Color>(&json);
+
+        // As serde_json::Error does not implement PartialEq, use debug print for comparison
+        assert_eq!(format!("{:#?}", response), format!("{:#?}", expected));
+    }
+
+    #[rstest]
+    #[case(0.4, 0.3, 0.9, Ok(Color::CIE_xyY { xy: CartesianCoordinate::new(x, y), brightness}))]
+    #[allow(non_snake_case)]
+    fn deserialize_xy_Y_values(#[case] x: f64, #[case] y: f64, #[case] brightness: f64, #[case] expected: serde_json::Result<Color>) {
+        let json = format!(
+            r#"{{
+                "x": {},
+                "y": {},
+                "Y": {}
+            }}"#,
+            x, y, brightness
+        );
+
+        let response = serde_json::from_str::<Color>(&json);
+
+        // As serde_json::Error does not implement PartialEq, use debug print for comparison
+        assert_eq!(format!("{:#?}", response), format!("{:#?}", expected));
+    }
+}

--- a/src/flow_loader/mod.rs
+++ b/src/flow_loader/mod.rs
@@ -1,3 +1,4 @@
+mod color_deserializer;
 mod factory;
 mod loader;
 mod property_value_deserializer;

--- a/src/hue/clip_to_gamut.rs
+++ b/src/hue/clip_to_gamut.rs
@@ -1,0 +1,61 @@
+use crate::domain::property::{CartesianCoordinate, Gamut};
+
+// Clip the xy coordinate to the given gamut
+pub fn clip_to_gamut(coordinate: CartesianCoordinate, gamut: &Gamut) -> CartesianCoordinate {
+    if is_in_gamut(&coordinate, gamut) {
+        return coordinate;
+    }
+
+    // Find the closest point on each edge of the gamut triangle
+    let point_red_green = closest_point_on_line(gamut.red(), gamut.green(), &coordinate);
+    let point_green_blue = closest_point_on_line(gamut.green(), gamut.blue(), &coordinate);
+    let point_blue_red = closest_point_on_line(gamut.blue(), gamut.red(), &coordinate);
+
+    // Calculate distances to each edge
+    let distance_red_green = squared_distance(&coordinate, &point_red_green);
+    let distance_green_blue = squared_distance(&coordinate, &point_green_blue);
+    let distance_blue_red = squared_distance(&coordinate, &point_blue_red);
+
+    // Return the closest point
+    if distance_red_green <= distance_green_blue && distance_red_green <= distance_blue_red {
+        point_red_green
+    } else if distance_green_blue <= distance_blue_red {
+        point_green_blue
+    } else {
+        point_blue_red
+    }
+}
+
+/// Check if a point is within the gamut triangle
+fn is_in_gamut(coordinate: &CartesianCoordinate, gamut: &Gamut) -> bool {
+    // Use cross product to check if point is inside triangle
+    let v0 = CartesianCoordinate::new(gamut.blue().x() - gamut.red().x(), gamut.blue().y() - gamut.red().y());
+    let v1 = CartesianCoordinate::new(gamut.green().x() - gamut.red().x(), gamut.green().y() - gamut.red().y());
+    let v2 = CartesianCoordinate::new(coordinate.x() - gamut.red().x(), coordinate.y() - gamut.red().y());
+
+    let dot00 = v0.x() * v0.x() + v0.y() * v0.y();
+    let dot01 = v0.x() * v1.x() + v0.y() * v1.y();
+    let dot02 = v0.x() * v2.x() + v0.y() * v2.y();
+    let dot11 = v1.x() * v1.x() + v1.y() * v1.y();
+    let dot12 = v1.x() * v2.x() + v1.y() * v2.y();
+
+    let inv_denom = 1.0 / (dot00 * dot11 - dot01 * dot01);
+    let u = (dot11 * dot02 - dot01 * dot12) * inv_denom;
+    let v = (dot00 * dot12 - dot01 * dot02) * inv_denom;
+
+    u >= 0.0 && v >= 0.0 && u + v <= 1.0
+}
+
+/// Find the closest point on a line segment to a given point
+fn closest_point_on_line(a: &CartesianCoordinate, b: &CartesianCoordinate, p: &CartesianCoordinate) -> CartesianCoordinate {
+    let ap = CartesianCoordinate::new(p.x() - a.x(), p.y() - a.y());
+    let ab = CartesianCoordinate::new(b.x() - a.x(), b.y() - a.y());
+    let ab2 = ab.x() * ab.x() + ab.y() * ab.y();
+    let ap_ab = ap.x() * ab.x() + ap.y() * ab.y();
+    let t = (ap_ab / ab2).max(0.0).min(1.0);
+    CartesianCoordinate::new(a.x() + ab.x() * t, a.y() + ab.y() * t)
+}
+
+fn squared_distance(a: &CartesianCoordinate, b: &CartesianCoordinate) -> f64 {
+    (a.x() - b.x()).powi(2) + (a.y() - b.y()).powi(2)
+}

--- a/src/hue/controller.rs
+++ b/src/hue/controller.rs
@@ -51,8 +51,8 @@ impl Controller for HueController {
                             .get(brightness_property.name())
                             .and_then(|pv| match pv {
                                 PropertyValue::SetNumberValue(value) => value.as_f64(),
-                                PropertyValue::IncrementNumberValue(value) => (brightness_property.value() + value.clone()).as_f64(),
-                                PropertyValue::DecrementNumberValue(value) => (brightness_property.value() - value.clone()).as_f64(),
+                                PropertyValue::IncrementNumberValue(value) => (brightness_property.value().unwrap_or(Number::PositiveInt(0)) + value.clone()).as_f64(),
+                                PropertyValue::DecrementNumberValue(value) => (brightness_property.value() .unwrap_or(Number::PositiveInt(0)) - value.clone()).as_f64(),
                                 _ => None,
                             })
                             .and_then(|brightness| match brightness_property.validate_value(Number::Float(brightness)) {

--- a/src/hue/domain/light_get.rs
+++ b/src/hue/domain/light_get.rs
@@ -17,14 +17,17 @@ pub struct LightGet {
 pub struct LightRequest {
     pub on: Option<On>,
     pub dimming: Option<SetDimming>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color_temperature: Option<SetColorTemperature>,
     pub color: Option<SetColor>,
 }
 
 impl LightRequest {
-    pub fn new(on: Option<On>, dimming: Option<f64>, color: Option<CartesianCoordinate>) -> Self {
+    pub fn new(on: Option<On>, dimming: Option<f64>, color_temperature: Option<u64>, color: Option<CartesianCoordinate>) -> Self {
         LightRequest {
             on,
             dimming: dimming.map(|brightness| SetDimming { brightness }),
+            color_temperature: color_temperature.map(|c| SetColorTemperature { mirek: c }),
             color: color.map(|c| SetColor { xy: Xy { x: c.x(), y: c.y() } }),
         }
     }
@@ -44,6 +47,11 @@ pub struct Dimming {
 #[derive(Debug, Serialize)]
 pub struct SetDimming {
     pub brightness: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SetColorTemperature {
+    pub mirek: u64,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/hue/domain/light_get.rs
+++ b/src/hue/domain/light_get.rs
@@ -17,13 +17,15 @@ pub struct LightGet {
 pub struct LightRequest {
     pub on: Option<On>,
     pub dimming: Option<SetDimming>,
+    pub color: Option<SetColor>,
 }
 
 impl LightRequest {
-    pub fn new(on: Option<On>, dimming: Option<f64>) -> Self {
+    pub fn new(on: Option<On>, dimming: Option<f64>, color: Option<CartesianCoordinate>) -> Self {
         LightRequest {
             on,
             dimming: dimming.map(|brightness| SetDimming { brightness }),
+            color: color.map(|c| SetColor { xy: Xy { x: c.x(), y: c.y() } }),
         }
     }
 }
@@ -42,6 +44,11 @@ pub struct Dimming {
 #[derive(Debug, Serialize)]
 pub struct SetDimming {
     pub brightness: f64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SetColor {
+    pub xy: Xy,
 }
 
 #[allow(dead_code)]
@@ -66,7 +73,7 @@ pub struct Color {
     pub gamut_type: GamutType,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Xy {
     pub x: f64,
     pub y: f64,

--- a/src/hue/domain/light_get.rs
+++ b/src/hue/domain/light_get.rs
@@ -108,7 +108,7 @@ pub struct LightChanged {
 
 #[derive(Debug, Deserialize)]
 pub struct ChangedColorTemperature {
-    pub mirek: u64, // >= 153 && <= 500, color temperature in mirek or null when the light color is not in the ct spectrum
+    pub mirek: Option<u64>, // >= 153 && <= 500, color temperature in mirek or null when the light color is not in the ct spectrum
     pub mirek_valid: bool,
 }
 

--- a/src/hue/map_light_changed.rs
+++ b/src/hue/map_light_changed.rs
@@ -18,19 +18,16 @@ pub fn map_light_changed_property(property: LightChanged) -> Vec<Event> {
         events.push(Event::NumberPropertyChanged {
             device_id: property.owner.rid.to_string(),
             property_id: "brightness".to_string(),
-            value: Number::Float(dimming.brightness),
+            value: Some(Number::Float(dimming.brightness)),
         });
     }
 
     if let Some(color_temperature) = property.color_temperature {
-        // This ignores mirek values that are not in the CT spectrum, but it should be handled
-        if let Some(mirek) = color_temperature.mirek {
-            events.push(Event::NumberPropertyChanged {
-                device_id: property.owner.rid.to_string(),
-                property_id: "colorTemperature".to_string(),
-                value: Number::PositiveInt(mirek.mirek_to_kelvin()),
-            });
-        }
+        events.push(Event::NumberPropertyChanged {
+            device_id: property.owner.rid.to_string(),
+            property_id: "colorTemperature".to_string(),
+            value: color_temperature.mirek.map(|m| Number::PositiveInt(m.mirek_to_kelvin())),
+        });
     }
 
     if let Some(color) = property.color {
@@ -122,7 +119,7 @@ mod tests {
             NumberPropertyChanged {
                 device_id: "84a3be14-5d90-4165-ac64-818b7981bb32".to_string(),
                 property_id: "brightness".to_string(),
-                value: Float(20.8),
+                value: Some(Float(20.8)),
             }
         );
     }
@@ -148,7 +145,7 @@ mod tests {
             NumberPropertyChanged {
                 device_id: "84a3be14-5d90-4165-ac64-818b7981bb32".to_string(),
                 property_id: "colorTemperature".to_string(),
-                value: PositiveInt(6535)
+                value: Some(PositiveInt(6535))
             }
         );
     }

--- a/src/hue/mod.rs
+++ b/src/hue/mod.rs
@@ -1,4 +1,5 @@
 mod client;
+mod clip_to_gamut;
 mod controller;
 mod discoverer;
 mod domain;


### PR DESCRIPTION
- Add support for color property value
- Add color temperature control to Hue lights
- Make the mirek field optional, consistent with the api
- Add color conversion functionality between RGB, Hex and Cie_xyY formats
- Clip the color gamut for Hue lights
- Add None value support for expressions