### PR TITLE
Schedule sunrise/sunset events

### DIFF
--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -7,6 +7,8 @@ pub mod events;
 mod geo_location;
 mod number;
 pub mod property;
+mod weekday;
 
 pub use geo_location::GeoLocation;
 pub use number::Number;
+pub use weekday::Weekday;

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -7,10 +7,12 @@ pub mod events;
 mod geo_location;
 mod number;
 pub mod property;
+mod time;
 mod weekday;
 mod weekday_condition;
 
 pub use geo_location::GeoLocation;
 pub use number::Number;
+pub use time::Time;
 pub use weekday::Weekday;
 pub use weekday_condition::WeekdayCondition;

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -8,7 +8,9 @@ mod geo_location;
 mod number;
 pub mod property;
 mod weekday;
+mod weekday_condition;
 
 pub use geo_location::GeoLocation;
 pub use number::Number;
 pub use weekday::Weekday;
+pub use weekday_condition::WeekdayCondition;

--- a/src/domain/time.rs
+++ b/src/domain/time.rs
@@ -1,0 +1,5 @@
+#[derive(PartialEq, Debug, Clone)]
+pub struct Time {
+    pub hour: u8,
+    pub minute: u8,
+}

--- a/src/domain/weekday.rs
+++ b/src/domain/weekday.rs
@@ -1,4 +1,5 @@
 use crate::domain::Weekday::*;
+use std::fmt::{Display, Formatter};
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub enum Weekday {
@@ -26,5 +27,39 @@ impl Weekday {
 
     pub fn all() -> [Weekday; 7] {
         [Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday]
+    }
+}
+
+impl Display for Weekday {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Monday => "Monday",
+            Tuesday => "Tuesday",
+            Wednesday => "Wednesday",
+            Thursday => "Thursday",
+            Friday => "Friday",
+            Saturday => "Saturday",
+            Sunday => "Sunday",
+        };
+        f.write_str(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(Monday, "Monday")]
+    #[case(Tuesday, "Tuesday")]
+    #[case(Wednesday, "Wednesday")]
+    #[case(Thursday, "Thursday")]
+    #[case(Friday, "Friday")]
+    #[case(Saturday, "Saturday")]
+    #[case(Sunday, "Sunday")]
+    fn test_display(#[case] condition: Weekday, #[case] expected: &str) {
+        assert_eq!(format!("{}", condition), expected);
     }
 }

--- a/src/domain/weekday.rs
+++ b/src/domain/weekday.rs
@@ -1,0 +1,30 @@
+use crate::domain::Weekday::*;
+
+#[derive(PartialEq, Eq, Hash, Debug, Clone)]
+pub enum Weekday {
+    Monday,
+    Tuesday,
+    Wednesday,
+    Thursday,
+    Friday,
+    Saturday,
+    Sunday,
+}
+
+impl Weekday {
+    pub fn as_index(&self) -> usize {
+        match self {
+            Monday => 0,
+            Tuesday => 1,
+            Wednesday => 2,
+            Thursday => 3,
+            Friday => 4,
+            Saturday => 5,
+            Sunday => 6,
+        }
+    }
+
+    pub fn all() -> [Weekday; 7] {
+        [Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday]
+    }
+}

--- a/src/domain/weekday_condition.rs
+++ b/src/domain/weekday_condition.rs
@@ -1,5 +1,6 @@
 use crate::domain::Weekday;
 use crate::domain::Weekday::{Friday, Monday, Saturday, Sunday, Thursday, Tuesday, Wednesday};
+use std::fmt::{Display, Formatter};
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum WeekdayCondition {
@@ -25,5 +26,51 @@ impl WeekdayCondition {
             WeekdayCondition::Weekdays => vec![Monday, Tuesday, Wednesday, Thursday, Friday],
             WeekdayCondition::Weekend => vec![Saturday, Sunday],
         }
+    }
+}
+
+impl Display for WeekdayCondition {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WeekdayCondition::Specific(day) => {
+                write!(f, "{}", day)
+            }
+            WeekdayCondition::Range { start, end } => {
+                write!(f, "{}-{}", start, end)
+            }
+            WeekdayCondition::Set(days) => {
+                let s = days.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ");
+                write!(f, "{}", s)
+            }
+            WeekdayCondition::Weekdays => {
+                write!(f, "weekdays")
+            }
+            WeekdayCondition::Weekend => {
+                write!(f, "weekend")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::monday(WeekdayCondition::Specific(Monday), "Monday")]
+    #[case::tuesday(WeekdayCondition::Specific(Tuesday), "Tuesday")]
+    #[case::wednesday(WeekdayCondition::Specific(Wednesday), "Wednesday")]
+    #[case::thursday(WeekdayCondition::Specific(Thursday), "Thursday")]
+    #[case::friday(WeekdayCondition::Specific(Friday), "Friday")]
+    #[case::saturday(WeekdayCondition::Specific(Saturday), "Saturday")]
+    #[case::sunday(WeekdayCondition::Specific(Sunday), "Sunday")]
+    #[case::range(WeekdayCondition::Range { start: Monday, end: Wednesday }, "Monday-Wednesday")]
+    #[case::set(WeekdayCondition::Set(vec![Tuesday, Wednesday, Friday]), "Tuesday, Wednesday, Friday")]
+    #[case::weekdays(WeekdayCondition::Weekdays, "weekdays")]
+    #[case::weekend(WeekdayCondition::Weekend, "weekend")]
+    fn test_display(#[case] condition: WeekdayCondition, #[case] expected: &str) {
+        assert_eq!(format!("{}", condition), expected);
     }
 }

--- a/src/domain/weekday_condition.rs
+++ b/src/domain/weekday_condition.rs
@@ -1,0 +1,29 @@
+use crate::domain::Weekday;
+use crate::domain::Weekday::{Friday, Monday, Saturday, Sunday, Thursday, Tuesday, Wednesday};
+
+#[derive(Clone, PartialEq, Debug)]
+pub enum WeekdayCondition {
+    Specific(Weekday),
+    Range { start: Weekday, end: Weekday },
+    Set(Vec<Weekday>),
+    Weekdays,
+    Weekend,
+}
+
+impl WeekdayCondition {
+    pub fn included_days(&self) -> Vec<Weekday> {
+        match self {
+            WeekdayCondition::Specific(day) => vec![day.clone()],
+            WeekdayCondition::Range { start, end } => {
+                let all = Weekday::all();
+                let start_index = start.as_index();
+                let end_index = end.as_index();
+
+                all[start_index..=end_index].to_vec()
+            }
+            WeekdayCondition::Set(days) => days.clone(),
+            WeekdayCondition::Weekdays => vec![Monday, Tuesday, Wednesday, Thursday, Friday],
+            WeekdayCondition::Weekend => vec![Saturday, Sunday],
+        }
+    }
+}

--- a/src/domain/weekday_condition.rs
+++ b/src/domain/weekday_condition.rs
@@ -9,6 +9,7 @@ pub enum WeekdayCondition {
     Set(Vec<Weekday>),
     Weekdays,
     Weekend,
+    Any,
 }
 
 impl WeekdayCondition {
@@ -25,6 +26,7 @@ impl WeekdayCondition {
             WeekdayCondition::Set(days) => days.clone(),
             WeekdayCondition::Weekdays => vec![Monday, Tuesday, Wednesday, Thursday, Friday],
             WeekdayCondition::Weekend => vec![Saturday, Sunday],
+            WeekdayCondition::Any => vec![Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday],
         }
     }
 }
@@ -48,6 +50,9 @@ impl Display for WeekdayCondition {
             WeekdayCondition::Weekend => {
                 write!(f, "weekend")
             }
+            WeekdayCondition::Any => {
+                write!(f, "any")
+            }
         }
     }
 }
@@ -70,6 +75,7 @@ mod tests {
     #[case::set(WeekdayCondition::Set(vec![Tuesday, Wednesday, Friday]), "Tuesday, Wednesday, Friday")]
     #[case::weekdays(WeekdayCondition::Weekdays, "weekdays")]
     #[case::weekend(WeekdayCondition::Weekend, "weekend")]
+    #[case::weekend(WeekdayCondition::Any, "any")]
     fn test_display(#[case] condition: WeekdayCondition, #[case] expected: &str) {
         assert_eq!(format!("{}", condition), expected);
     }

--- a/src/extensions/date_time_ext.rs
+++ b/src/extensions/date_time_ext.rs
@@ -1,0 +1,21 @@
+use crate::domain::Weekday;
+use crate::domain::Weekday::{Friday, Monday, Saturday, Sunday, Thursday, Tuesday, Wednesday};
+use chrono::{Datelike, TimeZone};
+
+pub trait ToWeekday {
+    fn to_weekday(&self) -> Weekday;
+}
+
+impl<Tz: TimeZone> ToWeekday for chrono::DateTime<Tz> {
+    fn to_weekday(&self) -> Weekday {
+        match self.weekday() {
+            chrono::Weekday::Mon => Monday,
+            chrono::Weekday::Tue => Tuesday,
+            chrono::Weekday::Wed => Wednesday,
+            chrono::Weekday::Thu => Thursday,
+            chrono::Weekday::Fri => Friday,
+            chrono::Weekday::Sat => Saturday,
+            chrono::Weekday::Sun => Sunday,
+        }
+    }
+}

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1,2 +1,3 @@
+pub mod date_time_ext;
 pub mod path_ext;
 pub mod unsigned_ints_ext;

--- a/src/flow_engine/context.rs
+++ b/src/flow_engine/context.rs
@@ -11,16 +11,8 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn new(snapshot: StoreSnapshot, location: GeoLocation) -> Self {
-        Context {
-            snapshot,
-            now: Local::now(),
-            location,
-        }
-    }
-
-    pub fn new_with_now(snapshot: StoreSnapshot, now: DateTime<Local>, location: GeoLocation) -> Self {
-        Context { snapshot, now, location }
+    pub fn builder() -> ContextBuilder {
+        ContextBuilder::default()
     }
 
     pub fn snapshot(&self) -> &StoreSnapshot {
@@ -48,5 +40,37 @@ impl Context {
             .with_altitude(self.location.altitude)
             .event_time(event)
             .with_timezone(&Local)
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct ContextBuilder {
+    snapshot: Option<StoreSnapshot>,
+    now: Option<DateTime<Local>>,
+    location: Option<GeoLocation>,
+}
+
+impl ContextBuilder {
+    pub fn snapshot(mut self, snapshot: StoreSnapshot) -> Self {
+        self.snapshot = Some(snapshot);
+        self
+    }
+
+    pub fn now(mut self, now: DateTime<Local>) -> Self {
+        self.now = Some(now);
+        self
+    }
+
+    pub fn location(mut self, location: GeoLocation) -> Self {
+        self.location = Some(location);
+        self
+    }
+
+    pub fn build(self) -> Context {
+        Context {
+            snapshot: self.snapshot.unwrap_or_default(),
+            now: self.now.unwrap_or_else(Local::now),
+            location: self.location.unwrap_or_default(),
+        }
     }
 }

--- a/src/flow_engine/expression.rs
+++ b/src/flow_engine/expression.rs
@@ -228,6 +228,7 @@ mod tests {
     use crate::domain::device::{Device, DeviceType};
     use crate::domain::property::{CartesianCoordinate, ColorProperty, Gamut, Property, Unit};
     use crate::domain::{GeoLocation, Weekday};
+    use crate::flow_engine::context::ContextBuilder;
     use crate::flow_engine::expression::Expression::*;
     use crate::flow_engine::expression::ExpressionError::{OperandTypeMismatch, UnaryOperandTypeMismatch};
     use crate::flow_engine::expression::TemporalExpression::{HasSunRisen, HasSunSet, IsAfterTime, IsBeforeTime, IsDaytime, IsNighttime, IsToday};
@@ -237,8 +238,12 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    fn context() -> Context {
-        Context::default()
+    fn context_with_location() -> ContextBuilder {
+        Context::builder().location(GeoLocation {
+            latitude: 51.9244,
+            longitude: 4.4777,
+            altitude: 0.0,
+        })
     }
 
     fn device() -> Device {
@@ -315,7 +320,7 @@ mod tests {
                 lhs: Box::new(Literal { value: Value::Number(lhs) }),
                 rhs: Box::new(Literal { value: Value::Number(rhs) }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap();
         assert_eq!(result, Value::Boolean(expected));
@@ -338,7 +343,7 @@ mod tests {
                 lhs: Box::new(Literal { value: Value::Number(lhs) }),
                 rhs: Box::new(Literal { value: Value::Number(rhs) }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap();
         assert_eq!(result, Value::Boolean(expected));
@@ -361,7 +366,7 @@ mod tests {
                 lhs: Box::new(Literal { value: Value::Number(lhs) }),
                 rhs: Box::new(Literal { value: Value::Number(rhs) }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap();
         assert_eq!(result, Value::Boolean(expected));
@@ -384,7 +389,7 @@ mod tests {
                 lhs: Box::new(Literal { value: Value::Number(lhs) }),
                 rhs: Box::new(Literal { value: Value::Number(rhs) }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap();
         assert_eq!(result, Value::Boolean(expected));
@@ -407,7 +412,7 @@ mod tests {
                 lhs: Box::new(Literal { value: Value::Number(lhs) }),
                 rhs: Box::new(Literal { value: Value::Number(rhs) }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap();
         assert_eq!(result, Value::Boolean(expected));
@@ -421,7 +426,7 @@ mod tests {
                 lhs: Box::new(Literal { value: lhs }),
                 rhs: Box::new(Literal { value: rhs }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap();
 
@@ -439,7 +444,7 @@ mod tests {
                 lhs: Box::new(Literal { value: Value::Boolean(lhs) }),
                 rhs: Box::new(Literal { value: Value::Boolean(rhs) }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap();
         assert_eq!(result, Value::Boolean(expected));
@@ -464,7 +469,7 @@ mod tests {
                 lhs: Box::new(Literal { value: lhs }),
                 rhs: Box::new(Literal { value: rhs }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap_err();
         assert_eq!(result, expected);
@@ -487,7 +492,7 @@ mod tests {
                 lhs: Box::new(Literal { value: Value::Number(lhs) }),
                 rhs: Box::new(Literal { value: Value::Number(rhs) }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap();
         assert_eq!(result, Value::Boolean(expected));
@@ -501,7 +506,7 @@ mod tests {
                 lhs: Box::new(Literal { value: lhs }),
                 rhs: Box::new(Literal { value: rhs }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap();
 
@@ -519,7 +524,7 @@ mod tests {
                 lhs: Box::new(Literal { value: Value::Boolean(lhs) }),
                 rhs: Box::new(Literal { value: Value::Boolean(rhs) }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap();
         assert_eq!(result, Value::Boolean(expected));
@@ -544,7 +549,7 @@ mod tests {
                 lhs: Box::new(Literal { value: lhs }),
                 rhs: Box::new(Literal { value: rhs }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap_err();
         assert_eq!(result, expected);
@@ -561,7 +566,7 @@ mod tests {
                 lhs: Box::new(Literal { value: Value::Boolean(lhs) }),
                 rhs: Box::new(Literal { value: Value::Boolean(rhs) }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap();
         assert_eq!(result, Value::Boolean(expected));
@@ -592,7 +597,7 @@ mod tests {
                 lhs: Box::new(Literal { value: lhs }),
                 rhs: Box::new(Literal { value: rhs }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap_err();
         assert_eq!(result, expected);
@@ -609,7 +614,7 @@ mod tests {
                 lhs: Box::new(Literal { value: Value::Boolean(lhs) }),
                 rhs: Box::new(Literal { value: Value::Boolean(rhs) }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap();
         assert_eq!(result, Value::Boolean(expected));
@@ -640,7 +645,7 @@ mod tests {
                 lhs: Box::new(Literal { value: lhs }),
                 rhs: Box::new(Literal { value: rhs }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap_err();
         assert_eq!(result, expected);
@@ -654,7 +659,7 @@ mod tests {
             &Not {
                 expression: Box::new(Literal { value: Value::Boolean(value) }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap();
         assert_eq!(result, Value::Boolean(expected));
@@ -676,7 +681,7 @@ mod tests {
             &Not {
                 expression: Box::new(Literal { value }),
             },
-            &context(),
+            &Context::default(),
         )
         .unwrap_err();
         assert_eq!(result, expected);
@@ -703,7 +708,7 @@ mod tests {
                 device_id: device_id.to_string(),
                 property_id: property_id.to_string(),
             },
-            &Context::new(snapshot, GeoLocation::default()),
+            &Context::builder().snapshot(snapshot).build(),
         );
 
         assert_eq!(result, expected);
@@ -725,7 +730,7 @@ mod tests {
                     when: WeekdayCondition::Specific(weekday),
                 },
             },
-            &Context::new_with_now(StoreSnapshot::default(), fixed_date_time, GeoLocation::default()),
+            &Context::builder().now(fixed_date_time).build(),
         )
         .unwrap();
         assert_eq!(result, Value::Boolean(expected));
@@ -739,11 +744,8 @@ mod tests {
     #[case::before_midnight(Time { hour: 23, minute: 59 }, true)]
     fn is_before_time(#[case] time: Time, #[case] expected: bool) {
         let fixed_date_time = Local.with_ymd_and_hms(2000, 8, 4, 12, 0, 0).unwrap();
-        let result = evaluate(
-            &Temporal { expression: IsBeforeTime { time } },
-            &Context::new_with_now(StoreSnapshot::default(), fixed_date_time, GeoLocation::default()),
-        )
-        .unwrap();
+        let context = &context_with_location().now(fixed_date_time).build();
+        let result = evaluate(&Temporal { expression: IsBeforeTime { time } }, &context).unwrap();
         assert_eq!(result, Value::Boolean(expected));
     }
 
@@ -755,11 +757,8 @@ mod tests {
     #[case::before_midnight(Time { hour: 23, minute: 59 }, false)]
     fn is_after_time(#[case] time: Time, #[case] expected: bool) {
         let fixed_date_time = Local.with_ymd_and_hms(2000, 8, 4, 12, 0, 0).unwrap();
-        let result = evaluate(
-            &Temporal { expression: IsAfterTime { time } },
-            &Context::new_with_now(StoreSnapshot::default(), fixed_date_time, GeoLocation::default()),
-        )
-        .unwrap();
+        let context = &context_with_location().now(fixed_date_time).build();
+        let result = evaluate(&Temporal { expression: IsAfterTime { time } }, &context).unwrap();
         assert_eq!(result, Value::Boolean(expected));
     }
 
@@ -770,19 +769,8 @@ mod tests {
     fn has_sun_risen(#[case] time: Time, #[case] expected: bool) {
         // Sunrise at given location and date: 2000-08-04T06:09:31+02:00
         let fixed_date_time = Local.with_ymd_and_hms(2000, 8, 4, time.hour as u32, time.minute as u32, 0).unwrap();
-        let result = evaluate(
-            &Temporal { expression: HasSunRisen },
-            &Context::new_with_now(
-                StoreSnapshot::default(),
-                fixed_date_time,
-                GeoLocation {
-                    latitude: 51.9244,
-                    longitude: 4.4777,
-                    altitude: 0.0,
-                },
-            ),
-        )
-        .unwrap();
+        let context = &context_with_location().now(fixed_date_time).build();
+        let result = evaluate(&Temporal { expression: HasSunRisen }, &context).unwrap();
         assert_eq!(result, Value::Boolean(expected));
     }
 
@@ -793,19 +781,8 @@ mod tests {
     fn has_sun_set(#[case] time: Time, #[case] expected: bool) {
         // Sunset at given location and date: 2000-08-04T21:26:42+02:00
         let fixed_date_time = Local.with_ymd_and_hms(2000, 8, 4, time.hour as u32, time.minute as u32, 0).unwrap();
-        let result = evaluate(
-            &Temporal { expression: HasSunSet },
-            &Context::new_with_now(
-                StoreSnapshot::default(),
-                fixed_date_time,
-                GeoLocation {
-                    latitude: 51.9244,
-                    longitude: 4.4777,
-                    altitude: 0.0,
-                },
-            ),
-        )
-        .unwrap();
+        let context = &context_with_location().now(fixed_date_time).build();
+        let result = evaluate(&Temporal { expression: HasSunSet }, &context).unwrap();
         assert_eq!(result, Value::Boolean(expected));
     }
 
@@ -816,19 +793,8 @@ mod tests {
     fn is_daytime(#[case] time: Time, #[case] expected: bool) {
         // Sunrise and sunset at given location and date: 2000-08-04T06:09:31+02:00 and 2000-08-04T21:26:42+02:00
         let fixed_date_time = Local.with_ymd_and_hms(2000, 8, 4, time.hour as u32, time.minute as u32, 0).unwrap();
-        let result = evaluate(
-            &Temporal { expression: IsDaytime },
-            &Context::new_with_now(
-                StoreSnapshot::default(),
-                fixed_date_time,
-                GeoLocation {
-                    latitude: 51.9244,
-                    longitude: 4.4777,
-                    altitude: 0.0,
-                },
-            ),
-        )
-        .unwrap();
+        let context = &context_with_location().now(fixed_date_time).build();
+        let result = evaluate(&Temporal { expression: IsDaytime }, &context).unwrap();
         assert_eq!(result, Value::Boolean(expected));
     }
 
@@ -839,19 +805,8 @@ mod tests {
     fn is_nighttime(#[case] time: Time, #[case] expected: bool) {
         // Sunrise and sunset at given location and date: 2000-08-04T06:09:31+02:00 and 2000-08-04T21:26:42+02:00
         let fixed_date_time = Local.with_ymd_and_hms(2000, 8, 4, time.hour as u32, time.minute as u32, 0).unwrap();
-        let result = evaluate(
-            &Temporal { expression: IsNighttime },
-            &Context::new_with_now(
-                StoreSnapshot::default(),
-                fixed_date_time,
-                GeoLocation {
-                    latitude: 51.9244,
-                    longitude: 4.4777,
-                    altitude: 0.0,
-                },
-            ),
-        )
-        .unwrap();
+        let context = &context_with_location().now(fixed_date_time).build();
+        let result = evaluate(&Temporal { expression: IsNighttime }, &context).unwrap();
         assert_eq!(result, Value::Boolean(expected));
     }
 }

--- a/src/flow_engine/expression.rs
+++ b/src/flow_engine/expression.rs
@@ -56,7 +56,7 @@ pub enum TemporalExpression {
     IsNighttime, // Now < sunrise or now > sunset
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum WeekdayCondition {
     Specific(Weekday),
     Range { start: Weekday, end: Weekday },
@@ -66,7 +66,7 @@ pub enum WeekdayCondition {
 }
 
 impl WeekdayCondition {
-    fn included_days(&self) -> Vec<Weekday> {
+    pub fn included_days(&self) -> Vec<Weekday> {
         match self {
             WeekdayCondition::Specific(day) => vec![day.clone()],
             WeekdayCondition::Range { start, end } => {
@@ -112,7 +112,7 @@ impl Weekday {
     }
 }
 
-trait ToWeekday {
+pub trait ToWeekday {
     fn to_weekday(&self) -> Weekday;
 }
 

--- a/src/flow_engine/expression.rs
+++ b/src/flow_engine/expression.rs
@@ -1,5 +1,5 @@
-use crate::domain::Number;
 use crate::domain::property::{BooleanProperty, NumberProperty, PropertyType};
+use crate::domain::{Number, Weekday};
 use crate::flow_engine::Context;
 use crate::flow_engine::expression::ExpressionError::UnknownProperty;
 use Weekday::*;
@@ -80,35 +80,6 @@ impl WeekdayCondition {
             WeekdayCondition::Weekdays => vec![Monday, Tuesday, Wednesday, Thursday, Friday],
             WeekdayCondition::Weekend => vec![Saturday, Sunday],
         }
-    }
-}
-
-#[derive(PartialEq, Eq, Hash, Debug, Clone)]
-pub enum Weekday {
-    Monday,
-    Tuesday,
-    Wednesday,
-    Thursday,
-    Friday,
-    Saturday,
-    Sunday,
-}
-
-impl Weekday {
-    pub fn as_index(&self) -> usize {
-        match self {
-            Monday => 0,
-            Tuesday => 1,
-            Wednesday => 2,
-            Thursday => 3,
-            Friday => 4,
-            Saturday => 5,
-            Sunday => 6,
-        }
-    }
-
-    pub fn all() -> [Weekday; 7] {
-        [Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday]
     }
 }
 

--- a/src/flow_engine/expression.rs
+++ b/src/flow_engine/expression.rs
@@ -1,5 +1,5 @@
 use crate::domain::property::{BooleanProperty, NumberProperty, PropertyType};
-use crate::domain::{Number, Weekday};
+use crate::domain::{Number, Weekday, WeekdayCondition};
 use crate::extensions::date_time_ext::ToWeekday;
 use crate::flow_engine::Context;
 use crate::flow_engine::expression::ExpressionError::UnknownProperty;
@@ -55,33 +55,6 @@ pub enum TemporalExpression {
     HasSunSet,   // Now >= sunset
     IsDaytime,   // Now between sunrise and sunset
     IsNighttime, // Now < sunrise or now > sunset
-}
-
-#[derive(Clone, PartialEq, Debug)]
-pub enum WeekdayCondition {
-    Specific(Weekday),
-    Range { start: Weekday, end: Weekday },
-    Set(Vec<Weekday>),
-    Weekdays,
-    Weekend,
-}
-
-impl WeekdayCondition {
-    pub fn included_days(&self) -> Vec<Weekday> {
-        match self {
-            WeekdayCondition::Specific(day) => vec![day.clone()],
-            WeekdayCondition::Range { start, end } => {
-                let all = Weekday::all();
-                let start_index = start.as_index();
-                let end_index = end.as_index();
-
-                all[start_index..=end_index].to_vec()
-            }
-            WeekdayCondition::Set(days) => days.clone(),
-            WeekdayCondition::Weekdays => vec![Monday, Tuesday, Wednesday, Thursday, Friday],
-            WeekdayCondition::Weekend => vec![Saturday, Sunday],
-        }
-    }
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/src/flow_engine/expression.rs
+++ b/src/flow_engine/expression.rs
@@ -1,9 +1,10 @@
 use crate::domain::property::{BooleanProperty, NumberProperty, PropertyType};
 use crate::domain::{Number, Weekday};
+use crate::extensions::date_time_ext::ToWeekday;
 use crate::flow_engine::Context;
 use crate::flow_engine::expression::ExpressionError::UnknownProperty;
 use Weekday::*;
-use chrono::{Datelike, NaiveTime, TimeZone};
+use chrono::NaiveTime;
 use serde::Deserialize;
 use std::cmp::Ordering;
 use thiserror::Error;
@@ -79,24 +80,6 @@ impl WeekdayCondition {
             WeekdayCondition::Set(days) => days.clone(),
             WeekdayCondition::Weekdays => vec![Monday, Tuesday, Wednesday, Thursday, Friday],
             WeekdayCondition::Weekend => vec![Saturday, Sunday],
-        }
-    }
-}
-
-pub trait ToWeekday {
-    fn to_weekday(&self) -> Weekday;
-}
-
-impl<Tz: TimeZone> ToWeekday for chrono::DateTime<Tz> {
-    fn to_weekday(&self) -> Weekday {
-        match self.weekday() {
-            chrono::Weekday::Mon => Monday,
-            chrono::Weekday::Tue => Tuesday,
-            chrono::Weekday::Wed => Wednesday,
-            chrono::Weekday::Thu => Thursday,
-            chrono::Weekday::Fri => Friday,
-            chrono::Weekday::Sat => Saturday,
-            chrono::Weekday::Sun => Sunday,
         }
     }
 }

--- a/src/flow_engine/flow.rs
+++ b/src/flow_engine/flow.rs
@@ -1,6 +1,6 @@
 use crate::flow_engine::Expression::Literal;
 use crate::flow_engine::action::Action;
-use crate::flow_engine::{Expression, Value};
+use crate::flow_engine::{Expression, Schedule, Value};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -10,7 +10,7 @@ use std::time::Duration;
 pub struct Flow {
     id: String,
     name: String,
-    schedule: Option<String>,
+    schedule: Option<Schedule>,
     trigger: Expression,
     start_node: Arc<FlowNode>,
     nodes_by_id: HashMap<String, Arc<FlowNode>>,
@@ -20,7 +20,7 @@ impl Flow {
     pub fn new(
         id: String,
         name: String,
-        schedule: Option<String>,
+        schedule: Option<Schedule>,
         trigger: Option<Expression>,
         start_node: Arc<FlowNode>,
         nodes_by_id: HashMap<String, Arc<FlowNode>>,
@@ -54,8 +54,8 @@ impl Flow {
         &self.trigger
     }
 
-    pub fn schedule(&self) -> Option<&str> {
-        self.schedule.as_deref()
+    pub fn schedule(&self) -> Option<Schedule> {
+        self.schedule.clone()
     }
 
     pub fn node_by_id(&self, id: &str) -> Option<&FlowNode> {

--- a/src/flow_engine/mod.rs
+++ b/src/flow_engine/mod.rs
@@ -13,6 +13,6 @@ pub use context::Context;
 pub use engine::FlowEngineError;
 pub use engine::FlowExecutionReport;
 pub use engine::execute;
-pub use expression::{Expression, Time, Value, Weekday, WeekdayCondition};
+pub use expression::{Expression, Time, Value, WeekdayCondition};
 pub use schedule::Schedule;
 pub use scheduler::{SchedulerCommand, scheduler};

--- a/src/flow_engine/mod.rs
+++ b/src/flow_engine/mod.rs
@@ -5,6 +5,7 @@ mod engine;
 mod expression;
 pub mod flow;
 pub mod property_value;
+mod schedule;
 pub mod scheduler;
 mod scope;
 
@@ -13,4 +14,5 @@ pub use engine::FlowEngineError;
 pub use engine::FlowExecutionReport;
 pub use engine::execute;
 pub use expression::{Expression, Time, Value, Weekday, WeekdayCondition};
+pub use schedule::Schedule;
 pub use scheduler::{SchedulerCommand, scheduler};

--- a/src/flow_engine/mod.rs
+++ b/src/flow_engine/mod.rs
@@ -13,6 +13,6 @@ pub use context::Context;
 pub use engine::FlowEngineError;
 pub use engine::FlowExecutionReport;
 pub use engine::execute;
-pub use expression::{Expression, Time, Value};
+pub use expression::{Expression, Value};
 pub use schedule::Schedule;
 pub use scheduler::{SchedulerCommand, scheduler};

--- a/src/flow_engine/mod.rs
+++ b/src/flow_engine/mod.rs
@@ -13,6 +13,6 @@ pub use context::Context;
 pub use engine::FlowEngineError;
 pub use engine::FlowExecutionReport;
 pub use engine::execute;
-pub use expression::{Expression, Time, Value, WeekdayCondition};
+pub use expression::{Expression, Time, Value};
 pub use schedule::Schedule;
 pub use scheduler::{SchedulerCommand, scheduler};

--- a/src/flow_engine/schedule.rs
+++ b/src/flow_engine/schedule.rs
@@ -2,6 +2,7 @@ use crate::domain::GeoLocation;
 use crate::flow_engine::WeekdayCondition;
 use crate::flow_engine::expression::ToWeekday;
 use chrono::{DateTime, Duration, NaiveDate, TimeZone, Utc};
+use std::fmt::{Display, Formatter};
 use std::ops::Add;
 use std::str::FromStr;
 use sunrise::{Coordinates, SolarDay};
@@ -11,6 +12,22 @@ pub enum Schedule {
     Cron(String),
     Sunrise { when: WeekdayCondition, offset: i64 },
     Sunset { when: WeekdayCondition, offset: i64 },
+}
+
+impl Display for Schedule {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Schedule::Cron(expression) => {
+                write!(f, "cron expression '{}'", expression)
+            }
+            Schedule::Sunrise { when, offset } => {
+                write!(f, "sunrise on {:?}, offset {}", when.included_days(), offset)
+            }
+            Schedule::Sunset { when, offset } => {
+                write!(f, "sunset on {:?}, offset {}", when.included_days(), offset)
+            }
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/flow_engine/schedule.rs
+++ b/src/flow_engine/schedule.rs
@@ -1,6 +1,5 @@
-use crate::domain::GeoLocation;
+use crate::domain::{GeoLocation, WeekdayCondition};
 use crate::extensions::date_time_ext::ToWeekday;
-use crate::flow_engine::WeekdayCondition;
 use chrono::{DateTime, Duration, NaiveDate, TimeZone, Utc};
 use std::fmt::{Display, Formatter};
 use std::ops::Add;

--- a/src/flow_engine/schedule.rs
+++ b/src/flow_engine/schedule.rs
@@ -1,8 +1,210 @@
+use crate::domain::GeoLocation;
 use crate::flow_engine::WeekdayCondition;
+use crate::flow_engine::expression::ToWeekday;
+use chrono::{DateTime, Duration, NaiveDate, TimeZone, Utc};
+use std::ops::Add;
+use std::str::FromStr;
+use sunrise::{Coordinates, SolarDay};
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum Schedule {
     Cron(String),
     Sunrise { when: WeekdayCondition, offset: i64 },
     Sunset { when: WeekdayCondition, offset: i64 },
+}
+
+#[derive(Debug)]
+enum SolarEvent {
+    Sunrise,
+    Sunset,
+}
+
+impl Schedule {
+    /// Returns an iterator which will return each `DateTime` that matches the schedule starting at the specified date and time.
+    pub fn after<Z>(&self, from: DateTime<Z>, location: GeoLocation) -> ScheduleIterator<Z>
+    where
+        Z: TimeZone,
+    {
+        match self {
+            Schedule::Cron(expression) => {
+                let schedule = cron::Schedule::from_str(expression).unwrap_or_else(|_| panic!("invalid cron expression '{}'", expression));
+                let iterator = schedule.after_owned(from);
+                ScheduleIterator::Cron(iterator)
+            }
+            Schedule::Sunrise { when, offset } => ScheduleIterator::SunEvent(SunEventIterator::new(location, from, when.clone(), *offset, SolarEvent::Sunrise)),
+            Schedule::Sunset { when, offset } => ScheduleIterator::SunEvent(SunEventIterator::new(location, from, when.clone(), *offset, SolarEvent::Sunset)),
+        }
+    }
+
+    /// Returns an iterator which will return each `DateTime` that matches the schedule starting at the current time.
+    pub fn upcoming<Z>(&self, timezone: Z, location: GeoLocation) -> ScheduleIterator<Z>
+    where
+        Z: TimeZone,
+    {
+        let now = Utc::now().with_timezone(&timezone);
+        self.after(now, location)
+    }
+}
+
+pub enum ScheduleIterator<Z>
+where
+    Z: TimeZone,
+{
+    Cron(cron::OwnedScheduleIterator<Z>),
+    SunEvent(SunEventIterator<Z>),
+}
+
+impl<Z> Iterator for ScheduleIterator<Z>
+where
+    Z: TimeZone,
+{
+    type Item = DateTime<Z>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            ScheduleIterator::Cron(iterator) => iterator.next(),
+            ScheduleIterator::SunEvent(iter) => iter.next(),
+        }
+    }
+}
+
+pub struct SunEventIterator<Z>
+where
+    Z: TimeZone,
+{
+    coordinates: Coordinates,
+    altitude: f64,
+    current: DateTime<Z>,
+    when: WeekdayCondition,
+    offset: i64,
+    solar_event: SolarEvent,
+}
+
+impl<Z> SunEventIterator<Z>
+where
+    Z: TimeZone,
+{
+    fn new(location: GeoLocation, current: DateTime<Z>, when: WeekdayCondition, offset: i64, solar_event: SolarEvent) -> Self {
+        let coordinates = Coordinates::new(location.latitude, location.longitude).expect("valid coordinates");
+        Self {
+            coordinates,
+            altitude: location.altitude,
+            current,
+            when,
+            offset,
+            solar_event,
+        }
+    }
+
+    fn event_time(&self, date: NaiveDate) -> DateTime<Z>
+    where
+        Z: TimeZone,
+    {
+        let event = match self.solar_event {
+            SolarEvent::Sunrise => sunrise::SolarEvent::Sunrise,
+            SolarEvent::Sunset => sunrise::SolarEvent::Sunset,
+        };
+
+        SolarDay::new(self.coordinates, date)
+            .with_altitude(self.altitude)
+            .event_time(event)
+            .with_timezone(&self.current.timezone())
+            .add(Duration::seconds(self.offset))
+    }
+}
+
+impl<Z> Iterator for SunEventIterator<Z>
+where
+    Z: TimeZone,
+{
+    type Item = DateTime<Z>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let date = self.current.clone();
+            self.current += Duration::days(1);
+            if !self.when.included_days().contains(&date.to_weekday()) {
+                continue;
+            }
+            let event_time = self.event_time(date.date_naive());
+            return Some(event_time);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::flow_engine::Weekday::*;
+    use chrono::{Datelike, NaiveDate};
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_schedule_with_cron() {
+        let schedule = Schedule::Cron("0 0 20 * * *".to_string());
+        let now = Utc.with_ymd_and_hms(2000, 8, 4, 12, 0, 0).unwrap();
+        let upcoming = schedule.after(now, location()).take(5).collect::<Vec<_>>();
+
+        // Notice that the nanoseconds are passed, that's done to ensure that the occurence is exactly at 20:00:00Z on the hour without subsecond drift
+        let first = NaiveDate::from_ymd_opt(2000, 8, 4).and_then(|dt| dt.and_hms_nano_opt(20, 0, 0, 0)).unwrap().and_utc();
+        assert_eq!(upcoming[0], first);
+        assert_eq!(upcoming[1], first.with_day(5).unwrap());
+        assert_eq!(upcoming[2], first.with_day(6).unwrap());
+        assert_eq!(upcoming[3], first.with_day(7).unwrap());
+        assert_eq!(upcoming[4], first.with_day(8).unwrap());
+    }
+
+    #[test]
+    fn test_schedule_with_sunrise_event() {
+        let schedule = Schedule::Sunrise {
+            when: WeekdayCondition::Range { start: Wednesday, end: Friday },
+            offset: 0,
+        };
+
+        let now = Utc.with_ymd_and_hms(2000, 8, 4, 12, 0, 0).unwrap(); // A Friday
+        let upcoming = schedule.after(now, location()).take(5).collect::<Vec<_>>();
+
+        assert_eq!(upcoming[0], Utc.with_ymd_and_hms(2000, 08, 04, 04, 10, 14).unwrap());
+        assert_eq!(upcoming[1], Utc.with_ymd_and_hms(2000, 08, 09, 04, 18, 11).unwrap());
+        assert_eq!(upcoming[2], Utc.with_ymd_and_hms(2000, 08, 10, 04, 19, 48).unwrap());
+        assert_eq!(upcoming[3], Utc.with_ymd_and_hms(2000, 08, 11, 04, 21, 24).unwrap());
+        assert_eq!(upcoming[4], Utc.with_ymd_and_hms(2000, 08, 16, 04, 29, 30).unwrap());
+
+        assert_eq!(upcoming[0].to_weekday(), Friday);
+        assert_eq!(upcoming[1].to_weekday(), Wednesday);
+        assert_eq!(upcoming[2].to_weekday(), Thursday);
+        assert_eq!(upcoming[3].to_weekday(), Friday);
+        assert_eq!(upcoming[4].to_weekday(), Wednesday);
+    }
+
+    #[test]
+    fn test_schedule_with_sunset_event() {
+        let schedule = Schedule::Sunset {
+            when: WeekdayCondition::Range { start: Wednesday, end: Friday },
+            offset: 0,
+        };
+
+        let now = Utc.with_ymd_and_hms(2000, 8, 4, 12, 0, 0).unwrap(); // A Friday
+        let upcoming = schedule.after(now, location()).take(5).collect::<Vec<_>>();
+
+        assert_eq!(upcoming[0], Utc.with_ymd_and_hms(2000, 08, 04, 19, 26, 57).unwrap());
+        assert_eq!(upcoming[1], Utc.with_ymd_and_hms(2000, 08, 09, 19, 17, 55).unwrap());
+        assert_eq!(upcoming[2], Utc.with_ymd_and_hms(2000, 08, 10, 19, 16, 02).unwrap());
+        assert_eq!(upcoming[3], Utc.with_ymd_and_hms(2000, 08, 11, 19, 14, 08).unwrap());
+        assert_eq!(upcoming[4], Utc.with_ymd_and_hms(2000, 08, 16, 19, 04, 17).unwrap());
+
+        assert_eq!(upcoming[0].to_weekday(), Friday);
+        assert_eq!(upcoming[1].to_weekday(), Wednesday);
+        assert_eq!(upcoming[2].to_weekday(), Thursday);
+        assert_eq!(upcoming[3].to_weekday(), Friday);
+        assert_eq!(upcoming[4].to_weekday(), Wednesday);
+    }
+
+    fn location() -> GeoLocation {
+        GeoLocation {
+            latitude: 51.8615899,
+            longitude: 4.3580323,
+            altitude: 0.0,
+        }
+    }
 }

--- a/src/flow_engine/schedule.rs
+++ b/src/flow_engine/schedule.rs
@@ -1,0 +1,8 @@
+use crate::flow_engine::WeekdayCondition;
+
+#[derive(Clone, PartialEq, Debug)]
+pub enum Schedule {
+    Cron(String),
+    Sunrise { when: WeekdayCondition, offset: i64 },
+    Sunset { when: WeekdayCondition, offset: i64 },
+}

--- a/src/flow_engine/schedule.rs
+++ b/src/flow_engine/schedule.rs
@@ -152,7 +152,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::flow_engine::Weekday::*;
+    use crate::domain::Weekday::*;
     use chrono::{Datelike, NaiveDate};
     use pretty_assertions::assert_eq;
 

--- a/src/flow_engine/schedule.rs
+++ b/src/flow_engine/schedule.rs
@@ -1,6 +1,6 @@
 use crate::domain::GeoLocation;
+use crate::extensions::date_time_ext::ToWeekday;
 use crate::flow_engine::WeekdayCondition;
-use crate::flow_engine::expression::ToWeekday;
 use chrono::{DateTime, Duration, NaiveDate, TimeZone, Utc};
 use std::fmt::{Display, Formatter};
 use std::ops::Add;

--- a/src/flow_engine/schedule.rs
+++ b/src/flow_engine/schedule.rs
@@ -17,13 +17,21 @@ impl Display for Schedule {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Schedule::Cron(expression) => {
-                write!(f, "cron expression '{}'", expression)
+                write!(f, "cron '{}'", expression)
             }
             Schedule::Sunrise { when, offset } => {
-                write!(f, "sunrise on {:?}, offset {}", when.included_days(), offset)
+                if offset == &0 {
+                    write!(f, "sunrise on {}", when)
+                } else {
+                    write!(f, "sunrise on {}, offset {}m", when, offset)
+                }
             }
             Schedule::Sunset { when, offset } => {
-                write!(f, "sunset on {:?}, offset {}", when.included_days(), offset)
+                if offset == &0 {
+                    write!(f, "sunset on {}", when)
+                } else {
+                    write!(f, "sunset on {}, offset {}m", when, offset)
+                }
             }
         }
     }

--- a/src/flow_engine/schedule.rs
+++ b/src/flow_engine/schedule.rs
@@ -125,7 +125,7 @@ where
             .with_altitude(self.altitude)
             .event_time(event)
             .with_timezone(&self.current.timezone())
-            .add(Duration::seconds(self.offset))
+            .add(Duration::minutes(self.offset))
     }
 }
 

--- a/src/flow_engine/scheduler.rs
+++ b/src/flow_engine/scheduler.rs
@@ -2,7 +2,7 @@ use crate::domain::GeoLocation;
 use crate::execute_flows::{execute_flow, execute_flows};
 use crate::flow_registry::FlowRegistry;
 use crate::store::StoreSnapshot;
-use chrono::Utc;
+use chrono::Local;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -48,8 +48,8 @@ pub async fn scheduler(
                 let tx_clone = tx.clone();
                 let geo_location_clone = geo_location.clone();
                 tokio::spawn(async move {
-                    for datetime in schedule.upcoming(Utc, geo_location_clone.clone()) {
-                        let duration = datetime.signed_duration_since(Utc::now());
+                    for datetime in schedule.upcoming(Local, geo_location_clone.clone()) {
+                        let duration = datetime.signed_duration_since(Local::now());
                         if duration.num_milliseconds() < 0 {
                             continue; // Already passed
                         }

--- a/src/flow_engine/scheduler.rs
+++ b/src/flow_engine/scheduler.rs
@@ -3,8 +3,6 @@ use crate::execute_flows::{execute_flow, execute_flows};
 use crate::flow_registry::FlowRegistry;
 use crate::store::StoreSnapshot;
 use chrono::Utc;
-use cron::Schedule;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -38,26 +36,19 @@ pub async fn scheduler(
                 let flow_name = flow.name().to_string();
                 debug!("🕗 Scheduling flow '{}'...", flow_name);
 
-                if flow.schedule().is_none() {
+                let Some(schedule) = flow.schedule() else {
                     error!("🕗 Scheduling flow '{}'... failed, not a scheduled flow", flow.name());
                     continue;
-                }
-
-                let cron = flow.schedule().unwrap().to_string(); // Safe because of the match guard
-                let schedule = match Schedule::from_str(&cron) {
-                    Ok(schedule) => schedule,
-                    Err(_e) => {
-                        warn!("🕗 Scheduling flow '{}'... failed, invalid cron expression '{}'", flow.name(), cron);
-                        continue;
-                    }
                 };
+
+                let schedule_str = schedule.to_string();
 
                 // Job loop
                 let notifier_rx_clone = notifier_rx.clone();
                 let tx_clone = tx.clone();
                 let geo_location_clone = geo_location.clone();
                 tokio::spawn(async move {
-                    for datetime in schedule.upcoming(Utc) {
+                    for datetime in schedule.upcoming(Utc, geo_location_clone.clone()) {
                         let duration = datetime.signed_duration_since(Utc::now());
                         if duration.num_milliseconds() < 0 {
                             continue; // Already passed
@@ -66,12 +57,12 @@ pub async fn scheduler(
                         let scheduled_instant = Instant::now() + Duration::from_millis(duration.num_milliseconds() as u64);
                         sleep_until(scheduled_instant).await;
 
-                        debug!(cron, "🕗 Running scheduled flow '{}'...", flow.name());
+                        debug!("🕗 Running scheduled flow '{}'...", flow.name());
                         let snapshot = notifier_rx_clone.borrow().clone();
                         execute_flows(vec![flow.clone()], snapshot, tx_clone.clone(), geo_location_clone.clone()).await;
                     }
                 });
-                info!("🕗 Scheduling flow '{}'... OK", flow_name);
+                info!(schedule = schedule_str, "🕗 Scheduling flow '{}'... OK", flow_name);
             }
             SchedulerCommand::ScheduleOnce { flow_id, node_id, delay } => {
                 let Some(flow) = flow_registry.by_id(&flow_id) else {

--- a/src/flow_loader/mod.rs
+++ b/src/flow_loader/mod.rs
@@ -2,6 +2,7 @@ mod color_deserializer;
 mod factory;
 mod loader;
 mod property_value_deserializer;
+mod schedule_deserializer;
 pub(in crate::flow_loader) mod serialized_flow;
 mod time_deserializer;
 mod value_deserializer;

--- a/src/flow_loader/schedule_deserializer.rs
+++ b/src/flow_loader/schedule_deserializer.rs
@@ -1,0 +1,118 @@
+use crate::flow_engine::{Schedule, WeekdayCondition};
+use serde::de::Error;
+use serde::{Deserialize, Deserializer};
+use serde_json::Value;
+
+impl<'de> Deserialize<'de> for Schedule {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+
+        match value {
+            Value::String(s) => Ok(Schedule::Cron(s)),
+            Value::Object(map) => {
+                let event = map.get("event").and_then(|v| v.as_str()).ok_or_else(|| Error::custom("missing or invalid field 'event'"))?;
+                let when_value = map.get("when").ok_or_else(|| Error::custom("missing or invalid field 'when'"))?;
+                let when = WeekdayCondition::deserialize(when_value).map_err(Error::custom)?;
+                let offset = map.get("offset").and_then(|v| v.as_i64()).unwrap_or(0);
+
+                match event {
+                    "sunrise" => Ok(Schedule::Sunrise { when, offset }),
+                    "sunset" => Ok(Schedule::Sunset { when, offset }),
+                    _ => Err(Error::custom(format!("unknown schedule event '{}'", event))),
+                }
+            }
+            _ => Err(Error::custom("a string containing a cron expression or an object with 'event', 'when' and 'offset'")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::flow_engine::Weekday::*;
+    use pretty_assertions::assert_eq;
+    use rstest::rstest;
+    use serde_json::json;
+
+    #[test]
+    fn deserializes_a_cron_expression() {
+        let parsed: Schedule = serde_json::from_value(json!("0 12 * * *")).unwrap();
+        let expected = Schedule::Cron("0 12 * * *".to_string());
+        assert_eq!(parsed, expected);
+    }
+
+    #[rstest]
+    #[case::with_cron_expression(
+        json!("0 12 * * *"),
+        Schedule::Cron("0 12 * * *".to_string())
+    )]
+    #[case::with_offset(
+        json!({
+            "event": "sunrise",
+            "when": "Wednesday",
+            "offset": 5
+        }),
+        Schedule::Sunrise { when: WeekdayCondition::Specific(Wednesday), offset: 5 }
+    )]
+    #[rstest]
+    #[case::with_negative_offset(
+        json!({
+            "event": "sunrise",
+            "when": "Wednesday",
+            "offset": -5
+        }),
+        Schedule::Sunrise { when: WeekdayCondition::Specific(Wednesday), offset: -5 }
+    )]
+    #[case::without_offset(
+        json!({
+            "event": "sunrise",
+            "when": "Wednesday-Saturday"
+        }),
+        Schedule::Sunrise { when: WeekdayCondition::Range { start: Wednesday, end: Saturday }, offset: 0 }
+    )]
+    fn deserializes_valid_values(#[case] json: Value, #[case] expected: Schedule) {
+        let parsed: Schedule = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, expected);
+    }
+
+    #[rstest]
+    #[case::no_event(
+        json!({
+            "when": "Wednesday-Saturday"
+        }),
+        "missing or invalid field 'event'"
+    )]
+    #[case::no_when(
+        json!({
+            "event": "sunrise",
+        }),
+        "missing or invalid field 'when'"
+    )]
+    #[case::unknown_event(
+        json!({
+            "event": "noon",
+            "when": "Wednesday-Saturday"
+        }),
+        "unknown schedule event 'noon'"
+    )]
+    #[case::invalid_when(
+        json!({
+            "event": "noon",
+            "when": 42
+        }),
+        "expected a string like 'Monday', 'Mon-Fri'"
+    )]
+    #[case::invalid_cron_expression(
+        json!(42),
+        "a string containing a cron expression or an object with 'event', 'when' and 'offset'"
+    )]
+    fn deserialize_fails_for_invalid_cases(#[case] json: Value, #[case] expected_message: &str) {
+        let parsed: Result<Schedule, _> = serde_json::from_value(json);
+        let err = parsed.expect_err("expected an error but got Ok");
+        let msg = err.to_string();
+        assert!(msg.contains(expected_message), "Expected error message to contain '{expected_message}', but got '{msg}'");
+    }
+}

--- a/src/flow_loader/schedule_deserializer.rs
+++ b/src/flow_loader/schedule_deserializer.rs
@@ -39,7 +39,7 @@ impl<'de> Deserialize<'de> for Schedule {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::flow_engine::Weekday::*;
+    use crate::domain::Weekday::*;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use serde_json::json;

--- a/src/flow_loader/schedule_deserializer.rs
+++ b/src/flow_loader/schedule_deserializer.rs
@@ -1,4 +1,5 @@
-use crate::flow_engine::{Schedule, WeekdayCondition};
+use crate::domain::WeekdayCondition;
+use crate::flow_engine::Schedule;
 use serde::de::{Error, Unexpected};
 use serde::{Deserialize, Deserializer};
 use serde_json::Value;

--- a/src/flow_loader/serialized_flow.rs
+++ b/src/flow_loader/serialized_flow.rs
@@ -1,5 +1,5 @@
-use crate::flow_engine::Expression;
 use crate::flow_engine::action::Action;
+use crate::flow_engine::{Expression, Schedule};
 use serde::Deserialize;
 use std::time::Duration;
 
@@ -7,7 +7,7 @@ use std::time::Duration;
 pub struct SerializedFlow {
     pub(crate) id: String,
     pub(crate) name: String,
-    pub(crate) schedule: Option<String>,
+    pub(crate) schedule: Option<Schedule>,
     pub(crate) trigger: Option<Expression>,
     pub(crate) nodes: Vec<SerializedFlowNode>,
 }

--- a/src/flow_loader/time_deserializer.rs
+++ b/src/flow_loader/time_deserializer.rs
@@ -1,4 +1,4 @@
-use crate::flow_engine::Time;
+use crate::domain::Time;
 use serde::de::{Error, Unexpected};
 use serde::{Deserialize, Deserializer};
 
@@ -34,7 +34,7 @@ impl<'de> Deserialize<'de> for Time {
             return Err(Error::invalid_value(Unexpected::Str(parts[0]), &"a valid minute between 0 and 59"));
         }
 
-        Ok(Time::new(hour, minute))
+        Ok(Time { hour, minute })
     }
 }
 
@@ -45,10 +45,10 @@ mod tests {
     use serde_json::json;
 
     #[rstest]
-    #[case("0:00", Time::new(0, 0))]
-    #[case("00:00", Time::new(0, 0))]
-    #[case("20:00", Time::new(20, 0))]
-    #[case("23:59", Time::new(23, 59))]
+    #[case("0:00", Time { hour: 0, minute: 0 })]
+    #[case("00:00", Time { hour: 0, minute: 0 })]
+    #[case("20:00", Time { hour: 20, minute:0 })]
+    #[case("23:59", Time { hour: 23, minute: 59 })]
     fn deserializes_valid_time(#[case] time: &str, #[case] expected: Time) {
         let result = serde_json::from_value::<Time>(json!(time)).unwrap();
         assert_eq!(result, expected);

--- a/src/flow_loader/weekday_condition_deserializer.rs
+++ b/src/flow_loader/weekday_condition_deserializer.rs
@@ -1,5 +1,4 @@
-use crate::domain::Weekday;
-use crate::flow_engine::WeekdayCondition;
+use crate::domain::{Weekday, WeekdayCondition};
 use serde::de::{SeqAccess, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, de};
 use std::fmt::Formatter;

--- a/src/flow_loader/weekday_condition_deserializer.rs
+++ b/src/flow_loader/weekday_condition_deserializer.rs
@@ -25,6 +25,7 @@ impl<'de> Deserialize<'de> for WeekdayCondition {
                 match value.as_str() {
                     "weekdays" => Ok(WeekdayCondition::Weekdays),
                     "weekend" => Ok(WeekdayCondition::Weekend),
+                    "any" => Ok(WeekdayCondition::Any),
                     _ => {
                         // Handle "Mon-Fri" or a single "Mon"
                         if let Some((start, end)) = value.split_once('-') {
@@ -99,6 +100,7 @@ mod tests {
     }
 
     #[rstest]
+    #[case::empty(vec![], WeekdayCondition::Set(vec![]))]
     #[case::two_days(vec!["Mon", "Wed"], WeekdayCondition::Set(vec![Monday, Wednesday]))]
     #[case::duplicates(vec!["Mon", "Wed", "Wed"], WeekdayCondition::Set(vec![Monday, Wednesday]))]
     fn deserialize_set(#[case] json: Vec<&str>, #[case] expected: WeekdayCondition) {

--- a/src/flow_loader/weekday_condition_deserializer.rs
+++ b/src/flow_loader/weekday_condition_deserializer.rs
@@ -1,4 +1,5 @@
-use crate::flow_engine::{Weekday, WeekdayCondition};
+use crate::domain::Weekday;
+use crate::flow_engine::WeekdayCondition;
 use serde::de::{SeqAccess, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, de};
 use std::fmt::Formatter;

--- a/src/flow_loader/weekday_deserializer.rs
+++ b/src/flow_loader/weekday_deserializer.rs
@@ -1,4 +1,4 @@
-use crate::flow_engine::Weekday;
+use crate::domain::Weekday;
 use serde::{Deserialize, Deserializer};
 
 impl<'de> Deserialize<'de> for Weekday {


### PR DESCRIPTION
- Add `Schedule` as an abstraction over `cron::Schedule` with support for sunrise and sunset events
- Sunrise/sunset times may have an offset specified in minutes
- Add a builder to `Context` to make tests more readable
- Use the local timezone instead of UTC in the scheduler
